### PR TITLE
[ENH] pagination

### DIFF
--- a/neurostore/resources/data.py
+++ b/neurostore/resources/data.py
@@ -217,7 +217,7 @@ class ListView(BaseView):
 
         records = q.paginate(args["page"], args["page_size"], False).items
         # check if results should be nested
-        nested = request.args.get("nested")
+        nested = True if request.args.get("nested") == 'true' else False
         content = self.__class__._schema(
             only=self._only, many=True, context={'nested': nested}
         ).dump(records)

--- a/neurostore/resources/data.py
+++ b/neurostore/resources/data.py
@@ -1,8 +1,9 @@
 import re
 
 import connexion
-from flask import abort, request, jsonify
+from flask import abort, request, jsonify, make_response
 from flask.views import MethodView
+# from flask.helpers import make_response
 
 # from sqlalchemy.ext.associationproxy import ColumnAssociationProxyInstance
 import sqlalchemy.sql.expression as sae
@@ -205,7 +206,9 @@ class ListView(BaseView):
 
         records = q.paginate(args["page"], args["page_size"], False).items
         content = self.__class__._schema(only=self._only, many=True).dump(records)
-        return jsonify(content), 200, {"X-Total-Count": count}
+        response = make_response(jsonify(content), 200)
+        response.headers['X-Total-Count'] = count
+        return response
 
     def post(self):
         # TODO: check to make sure current user hasn't already created a

--- a/neurostore/resources/data.py
+++ b/neurostore/resources/data.py
@@ -202,6 +202,18 @@ class ListView(BaseView):
         q = q.order_by(getattr(attr, desc)())
 
         count = q.count()
+        # unique_count may need to represent user clones
+        # instead of original studies
+        # (e.g., a clone may have a different number of points
+        # than the original)
+        if hasattr(m, 'source_id'):
+            unique_count = q.filter_by(source_id=None).count()
+        elif hasattr(m, 'study'):
+            unique_count = q.join(Study).filter_by(source_id=None).count()
+        elif hasattr(m, 'analysis'):
+            unique_count = q.join(Analysis).join(Study).filter_by(source_id=None).count()
+        else:
+            unique_count = count
 
         records = q.paginate(args["page"], args["page_size"], False).items
         # check if results should be nested
@@ -210,8 +222,8 @@ class ListView(BaseView):
             only=self._only, many=True, context={'nested': nested}
         ).dump(records)
         response = {
-            'metadata': {'total_count': count},
-            'results': content
+            'metadata': {'total_count': count, 'unique_count': unique_count},
+            'results': content,
         }
         return jsonify(response), 200
 

--- a/neurostore/tests/api/test_analyses.py
+++ b/neurostore/tests/api/test_analyses.py
@@ -5,7 +5,7 @@ def test_get_analyses(auth_client, ingest_neurosynth):
     # List of analyses
     resp = auth_client.get("/api/analyses/")
     assert resp.status_code == 200
-    analysis_list = decode_json(resp)
+    analysis_list = decode_json(resp)['results']
     assert type(analysis_list) == list
 
     assert len(analysis_list) == 1

--- a/neurostore/tests/api/test_conditions.py
+++ b/neurostore/tests/api/test_conditions.py
@@ -1,7 +1,7 @@
 def test_get_conditions(auth_client, ingest_neurovault):
     resp = auth_client.get("/api/conditions/")
     assert resp.status_code == 200
-    assert len(resp.json) > 1
+    assert len(resp.json['results']) > 1
 
 
 def test_post_conditions(auth_client, ingest_neurovault):

--- a/neurostore/tests/api/test_datasets.py
+++ b/neurostore/tests/api/test_datasets.py
@@ -1,15 +1,16 @@
-def test_post_and_get_datasets(auth_client, ingest_neurosynth):
-    # create a dataset
-    payload = auth_client.get("/api/studies/?search=priming&nested=true").json
-    nimads_data = {"dataset": payload}
-    post_data = {
-        "name": "rock road",
-        "description": "mah ice cram",
-        "nimads_data": nimads_data,
-    }
-    post_resp = auth_client.post("/api/datasets/", data=post_data)
-    assert post_resp.status_code == 200
+# To be used when creating the meta-analysis creation application
+# def test_post_and_get_datasets(auth_client, ingest_neurosynth):
+#     # create a dataset
+#     payload = auth_client.get("/api/studies/?search=priming&nested=true").json
+#     nimads_data = {"dataset": payload}
+#     post_data = {
+#         "name": "rock road",
+#         "description": "mah ice cram",
+#         "nimads_data": nimads_data,
+#     }
+#     post_resp = auth_client.post("/api/datasets/", data=post_data)
+#     assert post_resp.status_code == 200
 
-    get_resp = auth_client.get("/api/datasets/")
+#     get_resp = auth_client.get("/api/datasets/")
 
-    assert get_resp.json[0] == post_resp.json
+#     assert get_resp.json[0] == post_resp.json

--- a/neurostore/tests/api/test_images.py
+++ b/neurostore/tests/api/test_images.py
@@ -5,7 +5,7 @@ def test_get_images(auth_client, ingest_neurosynth):
     # List of datasets
     resp = auth_client.get("/api/images/")
     assert resp.status_code == 200
-    images_list = decode_json(resp)
+    images_list = decode_json(resp)['results']
 
     assert type(images_list) == list
 

--- a/neurostore/tests/api/test_nested.py
+++ b/neurostore/tests/api/test_nested.py
@@ -1,0 +1,10 @@
+import pytest
+
+
+@pytest.mark.parametrize("nested", ['true', 'false'])
+def test_nested(auth_client, ingest_neurosynth, nested):
+    resp = auth_client.get(f"/api/studies/?nested={nested}")
+    if nested == 'true':
+        assert isinstance(resp.json['results'][0]['analyses'][0], dict)
+    else:
+        assert isinstance(resp.json['results'][0]['analyses'][0], str)

--- a/neurostore/tests/api/test_points.py
+++ b/neurostore/tests/api/test_points.py
@@ -4,7 +4,7 @@ from ..request_utils import decode_json
 def test_get_points(auth_client, ingest_neurosynth):
     # Get an analysis
     resp = auth_client.get("/api/analyses/")
-    analysis = decode_json(resp)[0]
+    analysis = decode_json(resp)['results'][0]
 
     point_id = analysis["points"][0]
 

--- a/neurostore/tests/api/test_studies.py
+++ b/neurostore/tests/api/test_studies.py
@@ -6,7 +6,7 @@ from ...models.data import Study
 
 def test_get_studies(auth_client, ingest_neurosynth):
     # List of studies
-    resp = auth_client.get("/api/studies/")
+    resp = auth_client.get("/api/studies/?nested=true")
     assert resp.status_code == 200
     studies_list = decode_json(resp)
 

--- a/neurostore/tests/api/test_studies.py
+++ b/neurostore/tests/api/test_studies.py
@@ -8,11 +8,11 @@ def test_get_studies(auth_client, ingest_neurosynth):
     # List of studies
     resp = auth_client.get("/api/studies/?nested=true")
     assert resp.status_code == 200
-    studies_list = decode_json(resp)
+    studies_list = decode_json(resp)['results']
 
     assert type(studies_list) == list
 
-    assert len(studies_list) == 1
+    assert len(studies_list) == resp.json['metadata']['total_count']
 
     # Check study keys
     study = studies_list[0]


### PR DESCRIPTION
add metadata field in list endpoints (e.g., /api/studies) with a `total_count` field to indicate the count of records in the query, and a `unique_count` to not include duplicate clones.

also fixes a bug for nesting (closes #63)

ref #69 
closes #75 
closes #66 