### PR TITLE
[MAINT] add ipython to command `flask shell`

### DIFF
--- a/neurostore/requirements.txt
+++ b/neurostore/requirements.txt
@@ -7,6 +7,7 @@ flake8>=3.8.4
 flask>=2.0.0
 flask-cors>=3.0.10
 flask-dance>=3.2.0
+flask-shell-ipython>=0.4.1
 flask-migrate>=2.5.3,<3.0.0
 flask-security>=3.0.0
 gunicorn>=20.0.4


### PR DESCRIPTION
use ipython instead of regular python when typing `flask shell`