### PR TITLE
[ENH] annotation key

### DIFF
--- a/neurostore/ingest/__init__.py
+++ b/neurostore/ingest/__init__.py
@@ -22,7 +22,7 @@ from neurostore.models import (
     Study,
     Dataset,
 )
-from neurostore.models.data import DatasetStudy
+from neurostore.models.data import DatasetStudy, _check_type
 
 
 def ingest_neurovault(verbose=False, limit=20):
@@ -238,8 +238,8 @@ def ingest_neurosynth(max_rows=None):
                 )
 
         # add notes to annotation
+        annot.note_keys = {k: _check_type(v) for k, v in annotation_row._asdict().items()}
         annot.annotation_analyses = notes
-
         db.session.add(annot)
         db.session.commit()
 

--- a/neurostore/models/data.py
+++ b/neurostore/models/data.py
@@ -1,6 +1,6 @@
 from sqlalchemy import event, ForeignKeyConstraint
 from sqlalchemy.ext.associationproxy import association_proxy
-from sqlalchemy.orm.interfaces import EXT_STOP
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import relationship, backref
 from sqlalchemy.sql import func
@@ -276,6 +276,8 @@ def check_note_columns(mapper, connection, annotation):
 
     note_keys = annotation.note_keys
     aa_list = annotation.annotation_analyses
+    if not note_keys and aa_list:
+        raise SQLAlchemyError("Cannot have empty note_keys with annotations")
     for aa in aa_list:
         if set(note_keys.keys()) != set(aa.note.keys()):
             msg = "ERROR: "
@@ -285,14 +287,12 @@ def check_note_columns(mapper, connection, annotation):
                 msg = msg + f"Annotations are missing these keys: {nk_set - aa_set}. "
             if aa_set - nk_set:
                 msg = msg + f"Annotations have extra keys: {aa_set - nk_set}."
-            return EXT_STOP
-            raise ValueError(msg)
+            raise SQLAlchemyError(msg)
 
         for key, _type in note_keys.items():
             aa_type = _check_type(aa.note[key])
             if aa_type is not None and aa_type != _type:
-                return EXT_STOP
-                raise ValueError(f"value for key {key} is not of type {_type}")
+                raise SQLAlchemyError(f"value for key {key} is not of type {_type}")
 
 
 def add_necessary_annotation_analyses(dataset, studies, collection_adapter):

--- a/neurostore/models/data.py
+++ b/neurostore/models/data.py
@@ -1,5 +1,6 @@
 from sqlalchemy import event, ForeignKeyConstraint
 from sqlalchemy.ext.associationproxy import association_proxy
+from sqlalchemy.orm.interfaces import EXT_STOP
 from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import relationship, backref
 from sqlalchemy.sql import func
@@ -70,6 +71,7 @@ class Annotation(BaseMixin, db.Model):
     dataset_id = db.Column(db.Text, db.ForeignKey('datasets.id'))
     metadata_ = db.Column(db.JSON)
     public = db.Column(db.Boolean, default=True)
+    note_keys = db.Column(MutableDict.as_mutable(db.JSON))
     annotation_analyses = relationship(
         'AnnotationAnalysis',
         backref=backref("annotation"),
@@ -269,26 +271,28 @@ class PointValue(BaseMixin, db.Model):
     user = relationship("User", backref=backref("point_values"))
 
 
-def check_note_columns(annotation, annotation_analyses, collection_adapter):
-    "listen for the 'bulk_replace' event"
+def check_note_columns(mapper, connection, annotation):
+    """ensure note_keys and notes in annotationanalyses are consistent"""
 
-    def _combine_compare_keys(aa1, aa2):
-        """compare keys """
-        aa1_dict = {aa.analysis.id: set(aa.note.keys()) for aa in aa1}
-        aa2_dict = {aa.analysis.id: set(aa.note.keys()) for aa in aa2}
-        aa_dict = {}
-        for key in aa1_dict.keys():
-            if key in aa2_dict:
-                aa_dict[key] = aa2_dict.pop(key)
-            else:
-                aa_dict[key] = aa1_dict[key]
+    note_keys = annotation.note_keys
+    aa_list = annotation.annotation_analyses
+    for aa in aa_list:
+        if set(note_keys.keys()) != set(aa.note.keys()):
+            msg = "ERROR: "
+            nk_set = set(note_keys.keys())
+            aa_set = set(aa.note.keys())
+            if nk_set - aa_set:
+                msg = msg + f"Annotations are missing these keys: {nk_set - aa_set}. "
+            if aa_set - nk_set:
+                msg = msg + f"Annotations have extra keys: {aa_set - nk_set}."
+            return EXT_STOP
+            raise ValueError(msg)
 
-        aa_list = [*aa_dict.values(), *aa2_dict.values()]
-        return all([aa_list[0] == note for note in aa_list[1:]])
-
-    all_equal = _combine_compare_keys(annotation.annotation_analyses, annotation_analyses)
-    if not all_equal:
-        raise ValueError("All analyses must have the same annotations")
+        for key, _type in note_keys.items():
+            aa_type = _check_type(aa.note[key])
+            if aa_type is not None and aa_type != _type:
+                return EXT_STOP
+                raise ValueError(f"value for key {key} is not of type {_type}")
 
 
 def add_necessary_annotation_analyses(dataset, studies, collection_adapter):
@@ -316,8 +320,25 @@ def add_necessary_annotation_analyses(dataset, studies, collection_adapter):
         db.session.add_all(new_aas)
 
 
+def _check_type(x):
+    """check annotation key type"""
+    if isinstance(x, (int, float)):
+        return 'number'
+    elif isinstance(x, str):
+        return 'string'
+    elif isinstance(x, bool):
+        return 'boolean'
+    elif x is None:
+        return None
+    else:
+        return None
+
+
 # ensure all keys are the same across all notes
-event.listen(Annotation.annotation_analyses, 'bulk_replace', check_note_columns)
+event.listen(Annotation, 'before_insert', check_note_columns, retval=True)
+
+
+# event.listen(Annotation.annotation_analyses, 'bulk_replace', check_note_columns)
 
 
 # ensure new annotation_analyses are added when study is added to dataset

--- a/neurostore/resources/data.py
+++ b/neurostore/resources/data.py
@@ -6,6 +6,7 @@ from flask.views import MethodView
 
 # from sqlalchemy.ext.associationproxy import ColumnAssociationProxyInstance
 import sqlalchemy.sql.expression as sae
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy import func
 from webargs.flaskparser import parser
 from webargs import fields
@@ -125,7 +126,11 @@ class BaseView(MethodView):
 
                 if commit:
                     db.session.add_all(to_commit)
-                    db.session.commit()
+                    try:
+                        db.session.commit()
+                    except SQLAlchemyError as e:
+                        db.session.rollback()
+                        abort(400)
 
                 return record
 
@@ -175,7 +180,11 @@ class BaseView(MethodView):
 
         if commit:
             db.session.add_all(to_commit)
-            db.session.commit()
+            try:
+                db.session.commit()
+            except SQLAlchemyError as e:
+                db.session.rollback()
+                abort(400)
 
         return record
 

--- a/neurostore/resources/data.py
+++ b/neurostore/resources/data.py
@@ -128,7 +128,7 @@ class BaseView(MethodView):
                     db.session.add_all(to_commit)
                     try:
                         db.session.commit()
-                    except SQLAlchemyError as e:
+                    except SQLAlchemyError:
                         db.session.rollback()
                         abort(400)
 
@@ -182,7 +182,7 @@ class BaseView(MethodView):
             db.session.add_all(to_commit)
             try:
                 db.session.commit()
-            except SQLAlchemyError as e:
+            except SQLAlchemyError:
                 db.session.rollback()
                 abort(400)
 

--- a/neurostore/schemas/data.py
+++ b/neurostore/schemas/data.py
@@ -248,6 +248,7 @@ class AnnotationSchema(BaseDataSchema):
     source_id = fields.String(dump_only=True, db_only=True, allow_none=True)
     source_updated_at = fields.DateTime(dump_only=True, db_only=True, allow_none=True)
 
+    note_keys = fields.Dict()
     metadata = fields.Dict(attribute="metadata_", dump_only=True)
     # deserialization
     metadata_ = fields.Dict(data_key="metadata", load_only=True, allow_none=True)

--- a/neurostore/tests/api/test_annotations.py
+++ b/neurostore/tests/api/test_annotations.py
@@ -10,7 +10,9 @@ def test_post_annotation(auth_client, ingest_neurosynth):
         {'study': s.id, 'analysis': a.id, 'note': {'foo': a.id}}
         for s in dset.studies for a in s.analyses
     ]
-    payload = {'dataset': dset.id, 'notes': data, 'name': 'mah notes'}
+    payload = {
+        'dataset': dset.id, 'notes': data, 'note_keys': {'foo': 'string'}, 'name': 'mah notes'
+    }
     resp = auth_client.post('/api/annotations/', data=payload)
     assert resp.status_code == 200
 
@@ -134,7 +136,8 @@ def test_mismatched_notes(auth_client, ingest_neurosynth):
         {'study': s.id, 'analysis': a.id, 'note': {'foo': a.id, 'doo': s.id}}
         for s in dset.studies for a in s.analyses
     ]
-    payload = {'dataset': dset.id, 'notes': data, 'name': 'mah notes'}
+    note_keys = {'foo': 'string', 'doo': 'string'}
+    payload = {'dataset': dset.id, 'notes': data, 'note_keys': note_keys, 'name': 'mah notes'}
 
     # proper post
     annot = auth_client.post('/api/annotations/', data=payload)
@@ -164,7 +167,8 @@ def test_put_nonexistent_analysis(auth_client, ingest_neurosynth):
         {'study': s.id, 'analysis': a.id, 'note': {'foo': a.id, 'doo': s.id}}
         for s in dset.studies for a in s.analyses
     ]
-    payload = {'dataset': dset.id, 'notes': data, 'name': 'mah notes'}
+    note_keys = {'foo': 'string', 'doo': 'string'}
+    payload = {'dataset': dset.id, 'notes': data, 'note_keys': note_keys, 'name': 'mah notes'}
 
     # proper post
     annot = auth_client.post('/api/annotations/', data=payload)
@@ -185,7 +189,12 @@ def test_correct_note_overwrite(auth_client, ingest_neurosynth):
         {'study': s.id, 'analysis': a.id, 'note': {'foo': a.id, 'doo': s.id}}
         for s in dset.studies for a in s.analyses
     ]
-    payload = {'dataset': dset.id, 'notes': data, 'name': 'mah notes'}
+    payload = {
+        'dataset': dset.id,
+        'notes': data,
+        'note_keys': {'foo': 'string', 'doo': 'string'},
+        'name': 'mah notes',
+    }
 
     # proper post
     annot = auth_client.post('/api/annotations/', data=payload)

--- a/neurostore/tests/conftest.py
+++ b/neurostore/tests/conftest.py
@@ -315,6 +315,7 @@ def user_data(session, mock_add_users):
             annotation = Annotation(
                 name=name + 'annotation',
                 source='neurostore',
+                note_keys={'food': 'string'},
                 dataset=dataset,
                 user=user,
             )
@@ -356,6 +357,7 @@ def simple_neurosynth_annotation(session, ingest_neurosynth):
             name="smol " + annot.name,
             source="neurostore",
             dataset=annot.dataset,
+            note_keys={'animal': 'number'},
             annotation_analyses=smol_notes,
         )
     session.add(smol_annot)


### PR DESCRIPTION
references #210 

# relevant changes
- add `note_keys` parameter to annotations endpoint
- make it so you cannot push notes with different column names than specified in `note_keys`
- scenarios
  - creating annotation but have not created any columns yet
    - this is okay
  - adding notes to annotation without first//concurrently filling out `note_keys`
    - raises error
  - adding columns to `note_keys` but have not created any notes
    - this is okay
  - adding/removing/changing type existing `note_keys` and not simultaneously changing notes
    - raises error
  - adding/removing/changing note columns without simultaneously changing `note_keys`
    - raises error

@adelavega @nicoalee: here is the current behavior of this pull request, let me know if this looks reasonable or if y'all would want changes in how this pull request behaves to different scenarios.