### PR TITLE
fix: removed notes property from payload

### DIFF
--- a/synth/neurosynth-frontend/src/pages/Datasets/DatasetPage/DatasetPage.tsx
+++ b/synth/neurosynth-frontend/src/pages/Datasets/DatasetPage/DatasetPage.tsx
@@ -148,7 +148,6 @@ const DatasetPage: React.FC = (props) => {
                 name,
                 description,
                 note_keys: {},
-                notes: [],
                 dataset: params.datasetId,
             })
                 .then((res) => {


### PR DESCRIPTION
the notes property should be removed in order to communicate to the backend that we want notes to be autogenerated