### PR TITLE
[FIX] add api in context of current app

### DIFF
--- a/compose/neurosynth_compose/__init__.py
+++ b/compose/neurosynth_compose/__init__.py
@@ -22,13 +22,13 @@ def create_app():
     with app.app_context():
         connexion_app.add_api(
             "neurosynth-compose-openapi.yml",
-        base_path="/api",
-        options=options,
-        arguments={"title": "NeuroSynth API"},
-        resolver=MethodViewResolver("neurosynth_compose.resources"),
-        strict_validation=True,
-        validate_responses=True,
-    )
+            base_path="/api",
+            options=options,
+            arguments={"title": "NeuroSynth API"},
+            resolver=MethodViewResolver("neurosynth_compose.resources"),
+            strict_validation=True,
+            validate_responses=True,
+        )
 
     oauth = OAuth(app)
     auth0 = oauth.register(  # noqa: F841

--- a/compose/neurosynth_compose/__init__.py
+++ b/compose/neurosynth_compose/__init__.py
@@ -1,8 +1,6 @@
 import os
 
 from flask_cors import CORS
-from flask import current_app
-
 
 from authlib.integrations.flask_client import OAuth
 import connexion


### PR DESCRIPTION
connexion api is not being initialized correctly since auth.py requires variables from the app that are not created yet.

solution followed this pattern: 
https://stackoverflow.com/questions/53941243/how-to-pass-a-variable-into-connexion-flask-app-context