### PR TITLE
[FIX] do not prepend newline

### DIFF
--- a/compose/neurosynth-frontend/src/components/CodeSnippet/CodeSnippet.spec.tsx
+++ b/compose/neurosynth-frontend/src/components/CodeSnippet/CodeSnippet.spec.tsx
@@ -47,7 +47,7 @@ describe('CodeSnippet', () => {
 
             const copybutton = screen.getByRole('button', { name: 'copy' });
             userEvent.click(copybutton);
-            expect(navigator.clipboard.writeText).toHaveBeenCalledWith('\nexample 1\nexample 2');
+            expect(navigator.clipboard.writeText).toHaveBeenCalledWith('example 1\nexample 2');
         });
     });
 });

--- a/compose/neurosynth-frontend/src/components/CodeSnippet/CodeSnippet.tsx
+++ b/compose/neurosynth-frontend/src/components/CodeSnippet/CodeSnippet.tsx
@@ -7,7 +7,9 @@ const CodeSnippet: React.FC<{ linesOfCode: string[] }> = (props) => {
 
     const copyToClipboard = (_event: React.MouseEvent) => {
         setCopied(true);
-        const codeString = props.linesOfCode.reduce((prev, curr) => `${prev}\n${curr}`, '');
+        const codeString = props.linesOfCode.reduce((prev, curr, index) => {
+            return index === 0 ? curr : `${prev}\n${curr}`;
+        }, '');
         navigator.clipboard.writeText(codeString);
         setTimeout(() => {
             setCopied(false);


### PR DESCRIPTION
when copying code snippets do not prepend a newline.