### PR TITLE
[ENH] add ability to update study upon cloning

### DIFF
--- a/store/neurostore/resources/base.py
+++ b/store/neurostore/resources/base.py
@@ -529,13 +529,15 @@ class ListView(BaseView):
         args = parser.parse(self._user_args, request, location="query")
         source_id = args.get("source_id")
         source = args.get("source") or "neurostore"
+
+        unknown = self.__class__._schema.opts.unknown
+        data = parser.parse(
+            self.__class__._schema(exclude=("id",)), request, unknown=unknown
+        )
+
         if source_id:
-            data = self._load_from_source(source, source_id)
-        else:
-            unknown = self.__class__._schema.opts.unknown
-            data = parser.parse(
-                self.__class__._schema(exclude=("id",)), request, unknown=unknown
-            )
+            data = self._load_from_source(source, source_id, data)
+
         args["nested"] = bool(args.get("nested") or request.args.get("source_id"))
 
         with db.session.no_autoflush:

--- a/store/neurostore/resources/data.py
+++ b/store/neurostore/resources/data.py
@@ -192,10 +192,10 @@ class AnnotationsView(ObjectView, ListView):
     @classmethod
     def _load_from_source(cls, source, source_id, data=None):
         if source == "neurostore":
-            return cls.load_from_neurostore(source_id, data=None)
+            return cls.load_from_neurostore(source_id, data)
 
     @classmethod
-    def load_from_neurostore(cls, source_id):
+    def load_from_neurostore(cls, source_id, data=None):
         annotation = cls._model.query.filter_by(id=source_id).first_or_404()
         parent_source_id = annotation.source_id
         parent_source = annotation.source
@@ -451,11 +451,11 @@ class StudiesView(ObjectView, ListView):
         return clone_data
 
     @classmethod
-    def load_from_neurovault(cls, source_id):
+    def load_from_neurovault(cls, source_id, data=None):
         pass
 
     @classmethod
-    def load_from_pubmed(cls, source_id):
+    def load_from_pubmed(cls, source_id, data=None):
         pass
 
     def pre_nested_record_update(record):

--- a/store/neurostore/schemas/data.py
+++ b/store/neurostore/schemas/data.py
@@ -209,6 +209,7 @@ class PointSchema(BaseDataSchema):
     cluster_size = fields.Float(allow_none=True)
     subpeak = fields.Boolean(allow_none=True)
     order = fields.Integer()
+    coordinates = fields.List(fields.Float(), dump_only=True)
 
     # deserialization
     x = fields.Float(load_only=True)
@@ -216,8 +217,8 @@ class PointSchema(BaseDataSchema):
     z = fields.Float(load_only=True)
 
     class Meta:
-        additional = ("kind", "space", "coordinates", "image", "label_id")
-        allow_none = ("kind", "space", "coordinates", "image", "label_id")
+        additional = ("kind", "space", "image", "label_id")
+        allow_none = ("kind", "space", "image", "label_id")
 
     @pre_load
     def process_values(self, data, **kwargs):
@@ -225,6 +226,14 @@ class PointSchema(BaseDataSchema):
         if data.get("coordinates"):
             coords = [float(c) for c in data.pop("coordinates")]
             data["x"], data["y"], data["z"] = coords
+        return data
+
+    @pre_dump
+    def pre_dump_process(self, data, **kwargs):
+        if getattr(data, "coordinates", None) or data.get("coordinates"):
+            return data
+        if isinstance(data, dict):
+            data["coordinates"] = [data["x"], data["y"], data["z"]]
         return data
 
 

--- a/store/neurostore/tests/api/test_base_studies.py
+++ b/store/neurostore/tests/api/test_base_studies.py
@@ -58,7 +58,7 @@ def test_info_base_study(auth_client, ingest_neurosynth, session):
     assert single_reg_resp.status_code == 200
     info_fields = ["has_coordinates", "has_images", "studysets"]
     for field in info_fields:
-        assert field in single_info_resp.json()['versions'][0]
+        assert field in single_info_resp.json()["versions"][0]
     assert "id" in single_info_resp.json()["versions"][0]
     assert isinstance(single_reg_resp.json()["versions"][0], str)
 


### PR DESCRIPTION
should improve performance so that the frontend does not need to emit a nested put after cloning to keep track of edits
(note, the data in the request will "replace" whatever is in the source study, so if updating analyses, this acts like a put operation where the existing analyses will be replaced by whatever is in the request)