### PR TITLE
[FIX] set info to false when searching for base studies

### DIFF
--- a/compose/neurosynth-frontend/src/components/CurationComponents/CurationImport/CurationDoImport/ImportFromNeurostore/NeurostoreSearch.tsx
+++ b/compose/neurosynth-frontend/src/components/CurationComponents/CurationImport/CurationDoImport/ImportFromNeurostore/NeurostoreSearch.tsx
@@ -42,7 +42,7 @@ const NeurostoreSearch: React.FC<IImportArgs> = (props) => {
     });
 
     const { data, isLoading, isError, isFetching } = useGetDebouncedBaseStudies(
-        { ...searchCriteria, flat: true },
+        { ...searchCriteria, flat: true, info: false },
         !authenticationIsLoading
     );
 
@@ -97,6 +97,7 @@ const NeurostoreSearch: React.FC<IImportArgs> = (props) => {
                 ...searchCriteria,
                 pageOfResults: 1,
                 pageSize: 29999,
+                info: false,
             });
             const dataResults = allDataForSearch?.data?.results || [];
             if (dataResults.length !== studyData?.metadata?.total_count)


### PR DESCRIPTION
having info equal to true may cause additional sql queries while serializing, at some point should also look at the inverse, when flat should be false and info should be true.