### PR TITLE
[FIX] random ordering of elements

### DIFF
--- a/compose/neurosynth_compose/resources/analysis.py
+++ b/compose/neurosynth_compose/resources/analysis.py
@@ -353,7 +353,7 @@ class ListView(BaseView):
         # but weird things are happening. look into this as time allows.
         # if isinstance(attr, ColumnAssociationProxyInstance):
         #     q = q.join(*attr.attr)
-        q = q.order_by(getattr(attr, desc)())
+        q = q.order_by(getattr(attr, desc)(), m.id.desc())
 
         records = q.paginate(
             page=args["page"], per_page=args["page_size"], error_out=False

--- a/store/neurostore/resources/base.py
+++ b/store/neurostore/resources/base.py
@@ -505,7 +505,7 @@ class ListView(BaseView):
         # but weird things are happening. look into this as time allows.
         # if isinstance(attr, ColumnAssociationProxyInstance):
         #     q = q.join(*attr.attr)
-        q = q.order_by(getattr(attr, desc)())
+        q = q.order_by(getattr(attr, desc)(), m.id.desc())
 
         # join the relevant tables for output
         q = self.join_tables(q, args)

--- a/store/neurostore/tests/api/test_query_params.py
+++ b/store/neurostore/tests/api/test_query_params.py
@@ -67,8 +67,13 @@ def test_data_type(
 
 
 def test_page_size(auth_client, ingest_neurosynth, session):
-    get_page_size = auth_client.get("/api/studies/?page_size=5")
-    assert get_page_size.status_code == 200
+    num_studies = Study.query.count()
+    results = []
+    for i in range(1, num_studies+1):
+        get_page_size = auth_client.get(f"/api/studies/?page_size=1&page={i}")
+        assert get_page_size.status_code == 200
+        results.append(get_page_size.json()["results"][0]["id"])
+    assert len(set(results)) == num_studies
 
 
 def test_common_queries(auth_client, ingest_neurosynth, session):


### PR DESCRIPTION
if the sorting column has the same value for multiple rows, the behavior is not defined properly, so this pull request makes a secondary ordering column based on id so that the order of elements is deterministic.