### PR TITLE
[ENH] allow "post" to annotation-analysis endpoint

### DIFF
--- a/store/neurostore/resources/data.py
+++ b/store/neurostore/resources/data.py
@@ -1119,7 +1119,7 @@ class AnnotationAnalysesView(ObjectView, ListView):
         data = parser.parse(self.__class__._schema(many=True), request)
         args = parser.parse(self._user_args, request, location="query")
         schema = self._schema(many=True, context=args)
-        ids = {d.get("id"): d for d in data}
+        ids = {d.get("id"): d for d in data if d.get("id")}
         q = AnnotationAnalysis.query.filter(AnnotationAnalysis.id.in_(ids))
         q = self.eager_load(q, args)
         records = q.all()

--- a/store/neurostore/resources/data.py
+++ b/store/neurostore/resources/data.py
@@ -14,7 +14,7 @@ from sqlalchemy import select
 
 
 from .utils import view_maker
-from .base import BaseView, ObjectView, ListView
+from .base import BaseView, ObjectView, ListView, clear_cache
 from ..database import db
 from ..models import (
     User,
@@ -438,7 +438,6 @@ class BaseStudiesView(ObjectView, ListView):
         return super().join_tables(q, args)
 
     def post(self):
-        from .base import clear_cache
 
         # the request is either a list or a dict
         if isinstance(request.json, dict):
@@ -1115,6 +1114,36 @@ class AnnotationAnalysesView(ObjectView, ListView):
         "analysis": "AnalysesView",
         "studyset_study": "StudysetStudiesResource",
     }
+
+    def post(self):
+        data = parser.parse(self.__class__._schema(many=True), request)
+        args = parser.parse(self._user_args, request, location="query")
+        schema = self._schema(many=True, context=args)
+        ids = {d.get("id"): d for d in data}
+        q = AnnotationAnalysis.query.filter(AnnotationAnalysis.id.in_(ids))
+        q = self.eager_load(q, args)
+        records = q.all()
+        to_commit = []
+        for input_record in records:
+            with db.session.no_autoflush:
+                d = ids.get(input_record.id)
+                to_commit.append(
+                    self.__class__.update_or_create(d, id, record=input_record)
+                )
+
+        db.session.add_all(to_commit)
+
+        response = schema.dump(to_commit)
+
+        db.session.commit()
+
+        unique_ids = {
+            "annotation-analyses": set(list(ids)),
+            "annotations": {input_record.annotation_id},
+        }
+        clear_cache(unique_ids)
+
+        return response
 
     def eager_load(self, q, args=None):
         q = q.options(

--- a/store/neurostore/schemas/data.py
+++ b/store/neurostore/schemas/data.py
@@ -434,6 +434,13 @@ class AnnotationAnalysisSchema(BaseSchema):
         lambda aa: aa.studyset_study.study.publication, dump_only=True
     )
 
+    @pre_load
+    def create_id(self, data, **kwargs):
+        if not data.get("id") and data.get("annotation") and data.get("analysis"):
+            data["id"] = "_".join([data["annotation"], data["analysis"]])
+            data.pop("annotation")  # do not need to load/update annotation
+        return data
+
     @post_load
     def add_id(self, data, **kwargs):
         if isinstance(data.get("analysis_id"), str):

--- a/store/neurostore/tests/api/test_annotations.py
+++ b/store/neurostore/tests/api/test_annotations.py
@@ -381,15 +381,15 @@ def test_annotation_analyses_post(auth_client, ingest_neurosynth, session):
     new_value = "something new"
     data[0]["note"]["doo"] = new_value
     data[1]["note"]["doo"] = new_value
+    data[2]["note"]["doo"] = new_value  # will not be updated
     data[0]["id"] = annot.json()["id"] + "_" + data[0]["analysis"]
     data[1]["annotation"] = annot.json()["id"]
-    post_resp = auth_client.post("/api/annotation-analyses/", data=data[0:2])
+    post_resp = auth_client.post("/api/annotation-analyses/", data=data[0:3])
     assert post_resp.status_code == 200
 
     get_resp = auth_client.get(f"/api/annotations/{annot.json()['id']}")
-    # get_notes = sorted(get_resp.json()['notes'], key=lambda x: x['analysis'])
-    # put_notes = sorted(put_resp.json()['notes'], key=lambda x: x['analysis'])
-    assert len(post_resp.json()) == 2
+
+    assert len(post_resp.json()) == 2  # third input did not have proper id
     assert (
         get_resp.json()["notes"][1]["note"]["doo"]
         == post_resp.json()[1]["note"]["doo"]

--- a/store/neurostore/tests/api/test_annotations.py
+++ b/store/neurostore/tests/api/test_annotations.py
@@ -383,7 +383,7 @@ def test_annotation_analyses_post(auth_client, ingest_neurosynth, session):
     data[1]["note"]["doo"] = new_value
     data[0]["id"] = annot.json()["id"] + "_" + data[0]["analysis"]
     data[1]["annotation"] = annot.json()["id"]
-    post_resp = auth_client.post(f"/api/annotation-analyses/", data=data[0:2])
+    post_resp = auth_client.post("/api/annotation-analyses/", data=data[0:2])
     assert post_resp.status_code == 200
 
     get_resp = auth_client.get(f"/api/annotations/{annot.json()['id']}")


### PR DESCRIPTION
this should make updates to the annotations endpoint faster.

the input to the endpoint could have the "id" defined:

{'study': 'ZPyPo4SP6sH3', 'analysis': 'yzGFFBjnfH6z', 'note': {'foo': 'yzGFFBjnfH6z', 'doo': 'something new'}, 'id': 'Y2JkUwdLyWWa_yzGFFBjnfH6z'}

or "annotation" defined with "analysis":

{'study': 'DL3rswApkeAc', 'analysis': 'EV6sxCsNryF3', 'note': {'foo': 'EV6sxCsNryF3', 'doo': 'something new'}, 'annotation': 'Y2JkUwdLyWWa'}

if "id" or ("analysis" and "annotation") are not defined, the input will be ignored.