### PR TITLE
[FIX] keep numpy below 2.0 for now

### DIFF
--- a/store/neurostore/requirements.txt
+++ b/store/neurostore/requirements.txt
@@ -12,6 +12,7 @@ flask-migrate~=2.5
 flask-sqlalchemy~=3.1 # fix multiple instance error: https://flask-sqlalchemy.palletsprojects.com/en/3.0.x/changes/#version-3-0-3
 gunicorn~=22.0
 ipython~=7.19
+numpy<2.0.0
 pandas~=1.2
 pip-chill~=1.0
 psycopg2-binary~=2.8


### PR DESCRIPTION
with the new numpy release numerical representations changed.
https://github.com/numpy/numpy/releases/tag/v2.0.0