### PR TITLE
FIX: build directory now dist

### DIFF
--- a/compose/nginx/nginx.conf
+++ b/compose/nginx/nginx.conf
@@ -77,7 +77,7 @@ http {
         #include /etc/nginx/sites-enabled/*;
 	server {
 		server_name _;
-		root /compose/neurosynth-frontend/build;
+		root /compose/neurosynth-frontend/dist;
 
 		location /static/ {
 		}


### PR DESCRIPTION
VITE compiles into the dist directory (not build)