### PR TITLE
[FIX] flatten logic to pipeline-study-results endpoint

### DIFF
--- a/store/neurostore/resources/pipeline.py
+++ b/store/neurostore/resources/pipeline.py
@@ -64,6 +64,7 @@ class PipelineStudyResultsView(ObjectView, ListView):
         "feature_filter": fields.List(fields.String(), load_default=[]),
         "pipeline_config": fields.List(fields.String(), load_default=[]),
         "study_id": fields.List(fields.String(), load_default=[]),
+        "feature_flatten": fields.Bool(load_default=False),
     }
 
     def view_search(self, q, args):

--- a/store/neurostore/schemas/pipeline.py
+++ b/store/neurostore/schemas/pipeline.py
@@ -93,7 +93,11 @@ class PipelineStudyResultSchema(BaseSchema):
         data = {key: value for key, value in data.items() if value is not None}
 
         # Flatten result_data if it exists
-        if "result_data" in data and isinstance(data["result_data"], dict) and self.context.get("feature_flatten", False):
+        if (
+            "result_data" in data
+            and isinstance(data["result_data"], dict)
+            and self.context.get("feature_flatten", False)
+        ):
             # Get predictions section which contains our nested data
             result_data = data["result_data"]
             data["result_data"] = self.flatten_dict(result_data)

--- a/store/neurostore/schemas/pipeline.py
+++ b/store/neurostore/schemas/pipeline.py
@@ -93,7 +93,7 @@ class PipelineStudyResultSchema(BaseSchema):
         data = {key: value for key, value in data.items() if value is not None}
 
         # Flatten result_data if it exists
-        if "result_data" in data and isinstance(data["result_data"], dict):
+        if "result_data" in data and isinstance(data["result_data"], dict) and self.context.get("feature_flatten", False):
             # Get predictions section which contains our nested data
             result_data = data["result_data"]
             data["result_data"] = self.flatten_dict(result_data)

--- a/store/neurostore/tests/api/test_pipeline_resources.py
+++ b/store/neurostore/tests/api/test_pipeline_resources.py
@@ -198,14 +198,14 @@ def result3(pipeline_study_result_payload, session):
             "TestPipeline:1.0.0:nested.array[]=nested1",
             1,
             "nested1",
-            lambda x: x["result_data"]["nested.array"],
+            lambda x: x["result_data"]["nested"]["array"],
         ),
         # Test regex queries with version
         (
             "TestPipeline:1.0.0:nested.string~other",
             1,
             "other",
-            lambda x: x["result_data"]["nested.string"],
+            lambda x: x["result_data"]["nested"]["string"],
         ),
     ],
 )


### PR DESCRIPTION
do not automatically apply flattening logic to pipeline-study-results endpoint.