### PR TITLE
[FIX] filter newest results

### DIFF
--- a/store/neurostore/resources/data.py
+++ b/store/neurostore/resources/data.py
@@ -590,9 +590,11 @@ class BaseStudiesView(ObjectView, ListView):
                     )
                     .join(
                         PipelineAlias,
-                        PipelineConfigAlias.pipeline_id == PipelineAlias.id
+                        PipelineConfigAlias.pipeline_id == PipelineAlias.id,
                     )
-                    .filter(PipelineAlias.name == pipeline_name)  # Filter for specific pipeline
+                    .filter(
+                        PipelineAlias.name == pipeline_name
+                    )  # Filter for specific pipeline
                     .group_by(PipelineStudyResultAlias.base_study_id)
                     .subquery()
                 )
@@ -621,7 +623,6 @@ class BaseStudiesView(ObjectView, ListView):
                     )
                 )
                 pipeline_subqueries.append(pipeline_query.subquery())
-
 
             # Apply all config filters with unique parameter names for each filter
             for idx, (field_path, operator, value) in enumerate(

--- a/store/neurostore/tests/conftest.py
+++ b/store/neurostore/tests/conftest.py
@@ -736,7 +736,7 @@ def create_pipeline_results(session, ingest_neurosynth, tmp_path):
                         "inputs": {
                             f"/path/to/input/{study.id}.txt": f"md5{random.randint(0, 100)}"
                         },
-                        "date": "2025-03-05",
+                        "date": f"{random.randint(2024, 2030)}-{random.randint(1, 12):02d}-{random.randint(1, 28):02d}",
                     },
                     f,
                 )

--- a/store/neurostore/tests/conftest.py
+++ b/store/neurostore/tests/conftest.py
@@ -736,7 +736,11 @@ def create_pipeline_results(session, ingest_neurosynth, tmp_path):
                         "inputs": {
                             f"/path/to/input/{study.id}.txt": f"md5{random.randint(0, 100)}"
                         },
-                        "date": f"{random.randint(2024, 2030)}-{random.randint(1, 12):02d}-{random.randint(1, 28):02d}",
+                        "date": (
+                            f"{random.randint(2024, 2030)}"
+                            f"-{random.randint(1, 12):02d}"
+                            f"-{random.randint(1, 28):02d}"
+                        ),
                     },
                     f,
                 )


### PR DESCRIPTION
fix a bug where the newest result for a pipeline result was being compared to every new result across all pipelines, not just the pipeline being filtered on.