### PR TITLE
[ENH] add fields for fulltext and rank importance for search

### DIFF
--- a/store/neurostore/ingest/__init__.py
+++ b/store/neurostore/ingest/__init__.py
@@ -649,6 +649,7 @@ def ace_ingestion_logic(coordinates_df, metadata_df, text_df, skip_existing=Fals
                     authors=metadata_row.authors or None,
                     publication=metadata_row.journal or None,
                     description=text_row.abstract or None,
+                    ace_fulltext=text_row.body or None,
                     year=year,
                     level=level,
                 )

--- a/store/neurostore/models/data.py
+++ b/store/neurostore/models/data.py
@@ -182,11 +182,17 @@ class BaseStudy(BaseMixin, db.Model):
     has_coordinates = db.Column(db.Boolean, default=False, nullable=False)
     has_images = db.Column(db.Boolean, default=False, nullable=False)
     user_id = db.Column(db.Text, db.ForeignKey("users.external_id"), index=True)
+    ace_fulltext = db.Column(db.Text)
+    pubget_fulltext = db.Column(db.Text)
     _ts_vector = db.Column(
         "__ts_vector__",
         TSVector(),
         db.Computed(
-            "to_tsvector('english', coalesce(name, '') || ' ' || coalesce(description, ''))",
+            """
+            setweight(to_tsvector('english', coalesce(name, '')), 'A') ||
+            setweight(to_tsvector('english', coalesce(description, '')), 'B') ||
+            setweight(to_tsvector('english', coalesce(CASE WHEN pubget_fulltext IS NOT NULL THEN pubget_fulltext ELSE ace_fulltext END, '')), 'C')
+            """,
             persisted=True,
         ),
     )

--- a/store/neurostore/models/data.py
+++ b/store/neurostore/models/data.py
@@ -191,7 +191,15 @@ class BaseStudy(BaseMixin, db.Model):
             """
             setweight(to_tsvector('english', coalesce(name, '')), 'A') ||
             setweight(to_tsvector('english', coalesce(description, '')), 'B') ||
-            setweight(to_tsvector('english', coalesce(CASE WHEN pubget_fulltext IS NOT NULL THEN pubget_fulltext ELSE ace_fulltext END, '')), 'C')
+            setweight(to_tsvector('english',
+                coalesce(
+                    CASE
+                        WHEN pubget_fulltext IS NOT NULL THEN pubget_fulltext
+                        ELSE ace_fulltext
+                    END,
+                    ''
+                )
+            ), 'C')
             """,
             persisted=True,
         ),

--- a/store/neurostore/resources/base.py
+++ b/store/neurostore/resources/base.py
@@ -543,7 +543,7 @@ class ObjectView(BaseView):
 
 LIST_USER_ARGS = {
     "search": fields.String(load_default=None),
-    "sort": fields.String(load_default="created_at"),
+    "sort": fields.String(load_default=None),
     "page": fields.Int(load_default=1),
     "desc": fields.Boolean(load_default=True),
     "page_size": fields.Int(load_default=20, validate=lambda val: val < 30000),
@@ -597,7 +597,6 @@ class ListView(BaseView):
 
         m = self._model  # for brevity
         q = m.query
-        # q = q.options(raiseload("*", sql_only=True))
 
         # query items that are owned by a user_id
         if args.get("user_id"):
@@ -610,6 +609,7 @@ class ListView(BaseView):
 
         # Search
         s = args["search"]
+        rank_col = None
 
         # For multi-column search, default to using search fields
         # temporary fix for pmid search
@@ -621,6 +621,9 @@ class ListView(BaseView):
             except errors.SyntaxError as e:
                 abort(400, description=e.args[0])
             tsquery = func.to_tsquery("english", pubmed_to_tsquery(s))
+            # Add ts_rank calculation if searching
+            rank_col = func.ts_rank(m._ts_vector, tsquery).label("rank")
+            q = q.add_columns(rank_col)
             q = q.filter(m._ts_vector.op("@@")(tsquery))
 
         # Alternatively (or in addition), search on individual fields.
@@ -630,23 +633,28 @@ class ListView(BaseView):
                 q = q.filter(getattr(m, field).ilike(f"%{s}%"))
 
         q = self.view_search(q, args)
-        # Sort
-        sort_col = args["sort"]
+        
+        # Determine sort column based on context
         desc = args["desc"]
         desc = {False: "asc", True: "desc"}[desc]
 
-        attr = getattr(m, sort_col)
+        # If no sort specified, use ts_rank for search queries, otherwise created_at
+        sort_col = args["sort"]
+        if sort_col is None:
+            if rank_col is not None:
+                # Using ts_rank for search results
+                q = q.order_by(sa.text(f"rank {desc}"), m.id.desc())
+            else:
+                # Default to created_at when no search
+                q = q.order_by(m.created_at.desc(), m.id.desc())
+        else:
+            # Use user-specified sort column
+            attr = getattr(m, sort_col)
+            # Case-insensitive sorting
+            if sort_col not in ("created_at", "updated_at"):
+                attr = func.lower(attr)
+            q = q.order_by(getattr(attr, desc)(), m.id.desc())
 
-        # Case-insensitive sorting
-        if sort_col != "created_at" and sort_col != "updated_at":
-            attr = func.lower(attr)
-
-        # TODO: if the sort field is proxied, bad stuff happens. In theory
-        # the next two lines should address this by joining the proxied model,
-        # but weird things are happening. look into this as time allows.
-        # if isinstance(attr, ColumnAssociationProxyInstance):
-        #     q = q.join(*attr.attr)
-        q = q.order_by(getattr(attr, desc)(), getattr(m.id, desc)())
 
         # join the relevant tables for output
         q = self.eager_load(q, args)
@@ -661,6 +669,9 @@ class ListView(BaseView):
             total = pagination_query.total
         else:
             records = q.all()
+            # Extract actual records when using rank
+            if rank_col is not None:
+                records = [r[0] for r in records]
             total = len(records)
 
         content = self.serialize_records(records, args)

--- a/store/neurostore/resources/base.py
+++ b/store/neurostore/resources/base.py
@@ -633,7 +633,7 @@ class ListView(BaseView):
                 q = q.filter(getattr(m, field).ilike(f"%{s}%"))
 
         q = self.view_search(q, args)
-        
+
         # Determine sort column based on context
         desc = args["desc"]
         desc = {False: "asc", True: "desc"}[desc]
@@ -654,7 +654,6 @@ class ListView(BaseView):
             if sort_col not in ("created_at", "updated_at"):
                 attr = func.lower(attr)
             q = q.order_by(getattr(attr, desc)(), m.id.desc())
-
 
         # join the relevant tables for output
         q = self.eager_load(q, args)

--- a/store/neurostore/schemas/data.py
+++ b/store/neurostore/schemas/data.py
@@ -335,6 +335,8 @@ class BaseStudySchema(BaseDataSchema):
     metadata_ = fields.Dict(data_key="metadata", load_only=True, allow_none=True)
     versions = StringOrNested("StudySchema", many=True)
     features = fields.Method("get_features")
+    ace_fulltext = fields.String(load_only=True, allow_none=True)
+    pubget_fulltext = fields.String(load_only=True, allow_none=True)
 
     def get_features(self, obj):
         from .pipeline import PipelineStudyResultSchema


### PR DESCRIPTION
Here is the migration necessary to add to the columns:

```python
from alembic import op
import sqlalchemy as sa
from sqlalchemy.dialects import postgresql

def upgrade():
    # Add new columns
    op.add_column('base_studies', sa.Column('ace_fulltext', sa.Text(), nullable=True))
    op.add_column('base_studies', sa.Column('pubget_fulltext', sa.Text(), nullable=True))
    
    # Drop existing tsvector index
    op.drop_index('ix_base_study___ts_vector__', table_name='base_studies')
    
    # Update the computed column
    op.execute("""
        ALTER TABLE base_studies 
        DROP COLUMN __ts_vector__;
        
        ALTER TABLE base_studies
        ADD COLUMN __ts_vector__ tsvector 
        GENERATED ALWAYS AS (
            setweight(to_tsvector('english', coalesce(name, '')), 'A') ||
            setweight(to_tsvector('english', coalesce(description, '')), 'B') ||
            setweight(to_tsvector('english', coalesce(CASE 
                WHEN pubget_fulltext IS NOT NULL THEN pubget_fulltext 
                ELSE ace_fulltext 
            END, '')), 'C')
        ) STORED;
    """)
    
    # Recreate the index
    op.create_index('ix_base_study___ts_vector__', 'base_studies', ['__ts_vector__'], 
                   postgresql_using='gin')

def downgrade():
    # Drop new columns and revert tsvector
    op.drop_index('ix_base_study___ts_vector__', table_name='base_studies')
    
    op.execute("""
        ALTER TABLE base_studies 
        DROP COLUMN __ts_vector__;
        
        ALTER TABLE base_studies
        ADD COLUMN __ts_vector__ tsvector 
        GENERATED ALWAYS AS (
            to_tsvector('english', coalesce(name, '') || ' ' || coalesce(description, ''))
        ) STORED;
    """)
    
    op.create_index('ix_base_study___ts_vector__', 'base_studies', ['__ts_vector__'],
                   postgresql_using='gin')
    
    op.drop_column('base_studies', 'pubget_fulltext')
    op.drop_column('base_studies', 'ace_fulltext')
```