### PR TITLE
[FIX] fix how the records are parsed when ranked

### DIFF
--- a/store/neurostore/resources/base.py
+++ b/store/neurostore/resources/base.py
@@ -668,11 +668,11 @@ class ListView(BaseView):
             total = pagination_query.total
         else:
             records = q.all()
-            # Extract actual records when using rank
-            if rank_col is not None:
-                records = [r[0] for r in records]
             total = len(records)
 
+        if rank_col is not None:
+            # Extract actual records when using rank
+            records = [r[0] for r in records]
         content = self.serialize_records(records, args)
         metadata = self.create_metadata(q, total)
         response = {


### PR DESCRIPTION
the ranked query returns a tuple including the object and the numeric rank of the object, we just want to return the object

(maybe in the future we can set a threshold)