### PR TITLE
[FIX] add marshmallow version requirement

### DIFF
--- a/compose/neurosynth_compose/requirements.txt
+++ b/compose/neurosynth_compose/requirements.txt
@@ -16,7 +16,7 @@ flask-sqlalchemy~=3.0
 gunicorn~=22.0
 httpx~=0.22
 ipython~=7.19
-marshmallow~3.0
+marshmallow~=3.0
 pandas~=2.0
 pip-chill~=1.0
 psycopg2-binary~=2.8

--- a/compose/neurosynth_compose/requirements.txt
+++ b/compose/neurosynth_compose/requirements.txt
@@ -16,6 +16,7 @@ flask-sqlalchemy~=3.0
 gunicorn~=22.0
 httpx~=0.22
 ipython~=7.19
+marshmallow~3.0
 pandas~=2.0
 pip-chill~=1.0
 psycopg2-binary~=2.8

--- a/compose/setup.py
+++ b/compose/setup.py
@@ -12,7 +12,7 @@ requirements = [
     "flask-cors",
     "flask-sqlalchemy",
     "pyld",
-    "marshmallow>=3.0.0",
+    "marshmallow~=3.0.0",
     "webargs",
     "shortuuid",
     "pandas",

--- a/store/neurostore/requirements.txt
+++ b/store/neurostore/requirements.txt
@@ -12,6 +12,7 @@ flask-migrate~=2.5
 flask-sqlalchemy~=3.1 # fix multiple instance error: https://flask-sqlalchemy.palletsprojects.com/en/3.0.x/changes/#version-3-0-3
 gunicorn~=22.0
 ipython~=7.19
+marshmallow<4.0.0
 numpy<2.0.0
 pandas~=1.2
 pip-chill~=1.0

--- a/store/setup.py
+++ b/store/setup.py
@@ -12,7 +12,7 @@ requirements = [
     "flask-sqlalchemy",
     "pyld",
     "flask-graphql",
-    "marshmallow>=3.0.0",
+    "marshmallow<4.0.0",
     "webargs",
     "shortuuid",
     "pandas",


### PR DESCRIPTION
look into why marshmallow 4.0 is breaking (does not support many as a keyword argument anymore??):
`TypeError: Field.__init__() got an unexpected keyword argument 'many'`