### PR TITLE
fix: add property guard

### DIFF
--- a/compose/neurosynth-frontend/src/pages/Projects/components/ProjectsPageCard.tsx
+++ b/compose/neurosynth-frontend/src/pages/Projects/components/ProjectsPageCard.tsx
@@ -58,10 +58,10 @@ const ProjectsPageCard: React.FC<INeurosynthProjectReturn> = (props) => {
     }, [created_at]);
 
     const curationSummary = useMemo(() => {
-        if (provenance.curationMetadata.columns.length === 0) return;
+        if (!provenance?.curationMetadata?.columns || provenance.curationMetadata.columns.length === 0) return;
 
-        return getCurationSummary(provenance.curationMetadata.columns);
-    }, [provenance.curationMetadata.columns]);
+        return getCurationSummary(provenance?.curationMetadata?.columns);
+    }, [provenance?.curationMetadata?.columns]);
 
     const extractionSummary = useMemo(() => {
         if (!provenance.extractionMetadata.studysetId) return;


### PR DESCRIPTION
Received a bug:

```
TypeError: Cannot read properties of undefined (reading 'columns')
    at Re (ProjectsPage-D8-FTtS-.js:1:5539)
    at q6 (index--pcsx9b_.js:101:53129)
    at qbe (index--pcsx9b_.js:105:8787)
    at Gbe (index--pcsx9b_.js:105:965)
    at N4e (index--pcsx9b_.js:105:888)
    at JC (index--pcsx9b_.js:105:737)
    at MV (index--pcsx9b_.js:103:10883)
    at index--pcsx9b_.js:101:38913
    at e.unstable_runWithPriority (index--pcsx9b_.js:90:3795)
    at Jm (index--pcsx9b_.js:101:38687)
    at vbe (index--pcsx9b_.js:101:38859)
    at Fu (index--pcsx9b_.js:101:38792)
    at H4e (index--pcsx9b_.js:105:6843)
    at e.unstable_runWithPriority (index--pcsx9b_.js:90:3795)
    at Jm (index--pcsx9b_.js:101:38687)
    at Fh (index--pcsx9b_.js:105:6122)
    at index--pcsx9b_.js:105:6034
    at S (index--pcsx9b_.js:90:2849)
```

This should resolve the error