### PR TITLE
[FIX] increase shm_memory

### DIFF
--- a/store/docker-compose.yml
+++ b/store/docker-compose.yml
@@ -51,7 +51,7 @@ services:
     image: store-pgsql
     restart: always
     build: ./postgres
-    # shm_size: '256MB'  # if I'm going to increase work_mem in postgres, also increase this
+    shm_size: '256MB'
     volumes:
       - postgres_data:/var/lib/postgresql/data
     expose:


### PR DESCRIPTION
getting this error from small queries: psycopg2.errors.DiskFull: could not resize shared memory segment "/PostgreSQL.1566541588" to 4194304 bytes: No space left on device

likely from more people using the platform