### PR TITLE
[FIX] replace windows (\r\n) /old mac (\r) return carriages with (\n)

### DIFF
--- a/compose/neurosynth-frontend/src/pages/SleuthImport/components/SleuthImportWizardUpload.tsx
+++ b/compose/neurosynth-frontend/src/pages/SleuthImport/components/SleuthImportWizardUpload.tsx
@@ -45,7 +45,9 @@ const SleuthImportWizardUpload: React.FC<{
 
         for (const targetFile of [...event.target.files]) {
             try {
-                const parsedFile = await parseFile(targetFile);
+                let parsedFile = await parseFile(targetFile);
+                // Normalize Windows and lone carriage returns to Unix/Mac line endings
+                parsedFile = parsedFile.replace(/\r\n|\r/g, '\n');
                 uploadedFiles.push({
                     file: targetFile,
                     parsedFileContents: parsedFile,


### PR DESCRIPTION
files with windows line endings cannot be uploaded. This pull request should fix that issue.

[test_sleuth2.txt](https://github.com/user-attachments/files/22109542/test_sleuth2.txt)
