### PR TITLE
[REF] move devcontainers to base of repo

### DIFF
--- a/.devcontainer/compose/devcontainer.json
+++ b/.devcontainer/compose/devcontainer.json
@@ -7,18 +7,18 @@
 	// Update the 'dockerComposeFile' list if you have more compose files or use different names.
 	// The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.
 	"dockerComposeFile": [
-		"../docker-compose.yml",
-		"../docker-compose.dev.yml",
+		"../../compose/docker-compose.yml",
+		"../../compose/docker-compose.dev.yml",
 		"docker-compose.yml"
 	],
 
 	// The 'service' property is the name of the service for the container that VS Code should
 	// use. Update this value and .devcontainer/docker-compose.yml to the real service name.
-	"service": "neurostore",
+	"service": "compose",
 
 	// The optional 'workspaceFolder' property is the path VS Code should open by default when
 	// connected. This is typically a file mount in .devcontainer/docker-compose.yml
-	"workspaceFolder": "/neurostore",
+	"workspaceFolder": "/compose",
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
@@ -32,9 +32,8 @@
 		"ms-toolsai.jupyter",
 		"ms-python.vscode-pylance",
 		"ms-python.python",
-                "RooVeterinaryInc.roo-cline",
-
-	]
+		"RooVeterinaryInc.roo-cline"
+	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/.devcontainer/compose/docker-compose.yml
+++ b/.devcontainer/compose/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   # Update this to the name of the service you want to work with in your docker-compose.yml file
-  neurostore:
+  compose:
     # If you want add a non-root user to your Dockerfile, you can use the "remoteUser"
     # property in devcontainer.json to cause VS Code its sub-processes (terminals, tasks, 
     # debugging) to execute as the user. Uncomment the next line if you want the entire 
@@ -22,7 +22,7 @@ services:
     
     volumes:
       # Update this to wherever you want VS Code to mount the folder of your project
-      - .:/neurostore:cached
+      - ./compose:/compose:cached
 
       # Uncomment the next line to use Docker from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker-compose for details.
       # - /var/run/docker.sock:/var/run/docker.sock 

--- a/.devcontainer/store/devcontainer.json
+++ b/.devcontainer/store/devcontainer.json
@@ -7,18 +7,18 @@
 	// Update the 'dockerComposeFile' list if you have more compose files or use different names.
 	// The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.
 	"dockerComposeFile": [
-		"../docker-compose.yml",
-		"../docker-compose.dev.yml",
+		"../../store/docker-compose.yml",
+		"../../store/docker-compose.dev.yml",
 		"docker-compose.yml"
 	],
 
 	// The 'service' property is the name of the service for the container that VS Code should
 	// use. Update this value and .devcontainer/docker-compose.yml to the real service name.
-	"service": "compose",
+	"service": "neurostore",
 
 	// The optional 'workspaceFolder' property is the path VS Code should open by default when
 	// connected. This is typically a file mount in .devcontainer/docker-compose.yml
-	"workspaceFolder": "/compose",
+	"workspaceFolder": "/neurostore",
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
@@ -31,7 +31,8 @@
 		"eamodio.gitlens",
 		"ms-toolsai.jupyter",
 		"ms-python.vscode-pylance",
-		"ms-python.python"
+		"ms-python.python",
+        "RooVeterinaryInc.roo-cline",
 	]
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/.devcontainer/store/docker-compose.yml
+++ b/.devcontainer/store/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   # Update this to the name of the service you want to work with in your docker-compose.yml file
-  compose:
+  neurostore:
     # If you want add a non-root user to your Dockerfile, you can use the "remoteUser"
     # property in devcontainer.json to cause VS Code its sub-processes (terminals, tasks, 
     # debugging) to execute as the user. Uncomment the next line if you want the entire 
@@ -22,7 +22,7 @@ services:
     
     volumes:
       # Update this to wherever you want VS Code to mount the folder of your project
-      - .:/compose:cached
+      - ./store:/neurostore:cached
 
       # Uncomment the next line to use Docker from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker-compose for details.
       # - /var/run/docker.sock:/var/run/docker.sock 


### PR DESCRIPTION
This allows for codespaces/agents to use the testing environments.