### PR TITLE
[FIX] outside of application

### DIFF
--- a/compose/backend/neurosynth_compose/__init__.py
+++ b/compose/backend/neurosynth_compose/__init__.py
@@ -7,7 +7,7 @@ from connexion.resolver import MethodResolver
 from starlette.middleware.cors import CORSMiddleware
 
 from .database import init_db
-from .resources.auth import AuthError, handle_auth_error
+from .resources.auth import AuthError, handle_auth_error, init_app as init_auth
 
 
 def create_app():
@@ -73,6 +73,7 @@ def create_app():
     )
 
     init_db(app)
+    init_auth(app)
 
     app.secret_key = app.config["JWT_SECRET_KEY"]
 


### PR DESCRIPTION
another error from trying to use both flask and connexion:

```
compose-1          | ERROR:connexion.middleware.exceptions:RuntimeError('Working outside of application context.\n\nThis typically means that you attempted to use functionality that needed\nthe current application. To solve this, set up an application context\nwith app.app_context(). See the documentation for more information.')
compose-1          | Traceback (most recent call last):
compose-1          |   File "/usr/local/lib/python3.11/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
compose-1          |     await app(scope, receive, sender)
compose-1          |   File "/usr/local/lib/python3.11/site-packages/connexion/middleware/swagger_ui.py", line 220, in __call__
compose-1          |     await self.router(scope, receive, send)
compose-1          |   File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 716, in __call__
compose-1          |     await self.middleware_stack(scope, receive, send)
compose-1          |   File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 736, in app
compose-1          |     await route.handle(scope, receive, send)
compose-1          |   File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 462, in handle
compose-1          |     await self.app(scope, receive, send)
compose-1          |   File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 716, in __call__
compose-1          |     await self.middleware_stack(scope, receive, send)
compose-1          |   File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 766, in app
compose-1          |     await self.default(scope, receive, send)
compose-1          |   File "/usr/local/lib/python3.11/site-packages/connexion/middleware/swagger_ui.py", line 233, in default_fn
compose-1          |     await self.app(original_scope, receive, send)
compose-1          |   File "/usr/local/lib/python3.11/site-packages/connexion/middleware/routing.py", line 153, in __call__
compose-1          |     await self.router(scope, receive, send)
compose-1          |   File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 716, in __call__
compose-1          |     await self.middleware_stack(scope, receive, send)
compose-1          |   File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 736, in app
compose-1          |     await route.handle(scope, receive, send)
compose-1          |   File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 462, in handle
compose-1          |     await self.app(scope, receive, send)
compose-1          |   File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 716, in __call__
compose-1          |     await self.middleware_stack(scope, receive, send)
compose-1          |   File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 736, in app
compose-1          |     await route.handle(scope, receive, send)
compose-1          |   File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 290, in handle
compose-1          |     await self.app(scope, receive, send)
compose-1          |   File "/usr/local/lib/python3.11/site-packages/connexion/middleware/routing.py", line 47, in __call__
compose-1          |     await self.next_app(original_scope, receive, send)
compose-1          |   File "/usr/local/lib/python3.11/site-packages/connexion/middleware/abstract.py", line 268, in __call__
compose-1          |     return await operation(scope, receive, send)
compose-1          |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
compose-1          |   File "/usr/local/lib/python3.11/site-packages/connexion/middleware/security.py", line 99, in __call__
compose-1          |     await self.verification_fn(request)
compose-1          |   File "/usr/local/lib/python3.11/site-packages/connexion/security.py", line 575, in verify_fn
compose-1          |     cls._raise_most_specific(errors)
compose-1          |   File "/usr/local/lib/python3.11/site-packages/connexion/security.py", line 619, in _raise_most_specific
compose-1          |     raise status_to_exc[lowest_status_code]
compose-1          |   File "/usr/local/lib/python3.11/site-packages/connexion/security.py", line 567, in verify_fn
compose-1          |     token_info = await token_info
compose-1          |                  ^^^^^^^^^^^^^^^^
compose-1          |   File "/usr/local/lib/python3.11/site-packages/connexion/security.py", line 115, in wrapper
compose-1          |     token_info = func(*args, **kwargs)
compose-1          |                  ^^^^^^^^^^^^^^^^^^^^^
compose-1          |   File "/compose/backend/neurosynth_compose/resources/auth.py", line 72, in decode_token
compose-1          |     app = _get_current_app()
compose-1          |           ^^^^^^^^^^^^^^^^^^
compose-1          |   File "/compose/backend/neurosynth_compose/resources/auth.py", line 65, in _get_current_app
compose-1          |     return current_app._get_current_object()
compose-1          |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
compose-1          |   File "/usr/local/lib/python3.11/site-packages/werkzeug/local.py", line 519, in _get_current_object
compose-1          |     raise RuntimeError(unbound_message) from None
compose-1          | RuntimeError: Working outside of application context.
compose-1          | 
compose-1          | This typically means that you attempted to use functionality that needed
compose-1          | the current application. To solve this, set up an application context
compose-1          | with app.app_context(). See the documentation for more information.
compose-1          | ERROR:connexion.middleware.exceptions:RuntimeError('Working outside of application context.\n\nThis typically means that you attempted to use functionality that needed\nthe current application. To solve this, set up an application context\nwith app.app_context(). See the documentation for more information.')
compose-1          | Traceback (most recent call last):
compose-1          |   File "/usr/local/lib/python3.11/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
compose-1          |     await app(scope, receive, sender)
compose-1          |   File "/usr/local/lib/python3.11/site-packages/connexion/middleware/swagger_ui.py", line 220, in __call__
compose-1          |     await self.router(scope, receive, send)
compose-1          |   File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 716, in __call__
compose-1          |     await self.middleware_stack(scope, receive, send)
compose-1          |   File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 736, in app
compose-1          |     await route.handle(scope, receive, send)
compose-1          |   File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 462, in handle
compose-1          |     await self.app(scope, receive, send)
compose-1          |   File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 716, in __call__
compose-1          |     await self.middleware_stack(scope, receive, send)
compose-1          |   File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 766, in app
compose-1          |     await self.default(scope, receive, send)
compose-1          |   File "/usr/local/lib/python3.11/site-packages/connexion/middleware/swagger_ui.py", line 233, in default_fn
compose-1          |     await self.app(original_scope, receive, send)
compose-1          |   File "/usr/local/lib/python3.11/site-packages/connexion/middleware/routing.py", line 153, in __call__
compose-1          |     await self.router(scope, receive, send)
compose-1          |   File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 716, in __call__
compose-1          |     await self.middleware_stack(scope, receive, send)
compose-1          |   File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 736, in app
compose-1          |     await route.handle(scope, receive, send)
compose-1          |   File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 462, in handle
compose-1          |     await self.app(scope, receive, send)
compose-1          |   File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 716, in __call__
compose-1          |     await self.middleware_stack(scope, receive, send)
compose-1          |   File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 736, in app
compose-1          |     await route.handle(scope, receive, send)
compose-1          |   File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 290, in handle
compose-1          |     await self.app(scope, receive, send)
compose-1          |   File "/usr/local/lib/python3.11/site-packages/connexion/middleware/routing.py", line 47, in __call__
compose-1          |     await self.next_app(original_scope, receive, send)
compose-1          |   File "/usr/local/lib/python3.11/site-packages/connexion/middleware/abstract.py", line 268, in __call__
compose-1          |     return await operation(scope, receive, send)
compose-1          |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
compose-1          |   File "/usr/local/lib/python3.11/site-packages/connexion/middleware/security.py", line 99, in __call__
compose-1          |     await self.verification_fn(request)
compose-1          |   File "/usr/local/lib/python3.11/site-packages/connexion/security.py", line 575, in verify_fn
compose-1          |     cls._raise_most_specific(errors)
compose-1          |   File "/usr/local/lib/python3.11/site-packages/connexion/security.py", line 619, in _raise_most_specific
compose-1          |     raise status_to_exc[lowest_status_code]
compose-1          |   File "/usr/local/lib/python3.11/site-packages/connexion/security.py", line 567, in verify_fn
compose-1          |     token_info = await token_info
compose-1          |                  ^^^^^^^^^^^^^^^^
compose-1          |   File "/usr/local/lib/python3.11/site-packages/connexion/security.py", line 115, in wrapper
compose-1          |     token_info = func(*args, **kwargs)
compose-1          |                  ^^^^^^^^^^^^^^^^^^^^^
compose-1          |   File "/compose/backend/neurosynth_compose/resources/auth.py", line 72, in decode_token
compose-1          |     app = _get_current_app()
compose-1          |           ^^^^^^^^^^^^^^^^^^
compose-1          |   File "/compose/backend/neurosynth_compose/resources/auth.py", line 65, in _get_current_app
compose-1          |     return current_app._get_current_object()
compose-1          |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
compose-1          |   File "/usr/local/lib/python3.11/site-packages/werkzeug/local.py", line 519, in _get_current_object
compose-1          |     raise RuntimeError(unbound_message) from None
compose-1          | RuntimeError: Working outside of application context.
compose-1          | 
compose-1          | This typically means that you attempted to use functionality that needed
compose-1          | the current application. To solve this, set up an application context
compose-1          | with app.app_context(). See the documentation for more information.
```