### PR TITLE
[ENH] add ability to clone a project

### DIFF
--- a/compose/backend/neurosynth_compose/resources/analysis.py
+++ b/compose/backend/neurosynth_compose/resources/analysis.py
@@ -1,7 +1,9 @@
 from collections import ChainMap
+from copy import deepcopy
 import json
 import pathlib
 from operator import itemgetter
+from urllib.parse import urlencode
 
 import connexion
 from connexion.lifecycle import ConnexionResponse
@@ -50,6 +52,7 @@ from ..schemas import (  # noqa E401
     NeurostoreStudySchema,
     ProjectSchema,
 )
+from .neurostore import neurostore_session
 from .singular import singularize
 
 
@@ -697,6 +700,19 @@ class ProjectsView(ObjectView, ListView):
                     )
 
     def post(self):
+        clone_args = parser.parse(
+            {
+                "source_id": fields.String(missing=None),
+                "copy_annotations": fields.Boolean(missing=True),
+            },
+            request,
+            location="query",
+        )
+
+        source_id = clone_args.get("source_id")
+        if source_id:
+            return self._clone_project(source_id, clone_args.get("copy_annotations", True))
+
         try:
             data = parser.parse(self.__class__._schema, request)
         except ValidationError as e:
@@ -704,7 +720,6 @@ class ProjectsView(ObjectView, ListView):
 
         with db.session.no_autoflush:
             record = self.__class__.update_or_create(data)
-            # create neurostore study
             ns_study = NeurostoreStudy(project=record)
             db.session.add(ns_study)
             commit_session()
@@ -713,6 +728,264 @@ class ProjectsView(ObjectView, ListView):
             commit_session()
         payload = self.__class__._schema().dump(record)
         return _make_json_response(payload)
+
+    def _clone_project(self, source_id, copy_annotations):
+        current_user = self._ensure_current_user()
+
+        source_project = db.session.execute(
+            select(Project)
+            .options(
+                selectinload(Project.studyset).options(
+                    selectinload(Studyset.studyset_reference)
+                ),
+                selectinload(Project.annotation).options(
+                    selectinload(Annotation.annotation_reference)
+                ),
+                selectinload(Project.meta_analyses).options(
+                    selectinload(MetaAnalysis.specification).options(
+                        selectinload(Specification.specification_conditions)
+                    ),
+                    selectinload(MetaAnalysis.results),
+                ),
+            )
+            .where(Project.id == source_id)
+        ).scalar_one_or_none()
+
+        if source_project is None:
+            abort(404)
+
+        if not source_project.public and source_project.user_id != current_user.external_id:
+            abort(403, description="project is not public")
+
+        access_token = request.headers.get("Authorization")
+        if not access_token:
+            from auth0.v3.authentication.get_token import GetToken
+
+            domain = current_app.config["AUTH0_BASE_URL"].lstrip("https://")
+            g_token = GetToken(domain)
+            token_resp = g_token.client_credentials(
+                client_id=current_app.config["AUTH0_CLIENT_ID"],
+                client_secret=current_app.config["AUTH0_CLIENT_SECRET"],
+                audience=current_app.config["AUTH0_API_AUDIENCE"],
+            )
+            access_token = " ".join([token_resp["token_type"], token_resp["access_token"]])
+
+        ns_session = neurostore_session(access_token)
+
+        with db.session.no_autoflush:
+            new_studyset, new_annotation = self._clone_studyset_and_annotation(
+                ns_session, source_project, current_user, copy_annotations
+            )
+
+            cloned_project = Project(
+                name=source_project.name,
+                description=source_project.description,
+                provenance=self._clone_provenance(
+                    source_project.provenance,
+                    new_studyset.studyset_reference.id if new_studyset else None,
+                    new_annotation.annotation_reference.id if new_annotation else None,
+                ),
+                user=current_user,
+                public=False,
+                draft=True,
+                studyset=new_studyset,
+                annotation=new_annotation,
+            )
+
+            cloned_metas = []
+            for meta in source_project.meta_analyses:
+                cloned_meta = self._clone_meta_analysis(
+                    meta,
+                    current_user,
+                    cloned_project,
+                    new_studyset,
+                    new_annotation,
+                )
+                cloned_metas.append(cloned_meta)
+
+            cloned_project.meta_analyses = cloned_metas
+
+            db.session.add(cloned_project)
+            for meta in cloned_metas:
+                db.session.add(meta)
+
+            commit_session()
+
+            ns_study = NeurostoreStudy(project=cloned_project)
+            db.session.add(ns_study)
+            commit_session()
+            create_or_update_neurostore_study(ns_study)
+            db.session.add(ns_study)
+            commit_session()
+
+        payload = self.__class__._schema().dump(cloned_project)
+        return _make_json_response(payload)
+
+    def _ensure_current_user(self):
+        current_user = get_current_user()
+        if current_user:
+            return current_user
+        current_user = create_user()
+        if current_user:
+            db.session.add(current_user)
+            commit_session()
+            return current_user
+        abort(401, description="user authentication required")
+
+    def _clone_studyset_and_annotation(
+        self, ns_session, source_project, current_user, copy_annotations
+    ):
+        source_studyset = getattr(source_project, "studyset", None)
+        new_studyset = None
+        new_annotation = None
+
+        if source_studyset and source_studyset.studyset_reference:
+            query_params = {
+                "source_id": source_studyset.studyset_reference.id,
+            }
+            if copy_annotations is not None:
+                query_params["copy_annotations"] = str(bool(copy_annotations)).lower()
+
+            path = "/api/studysets/"
+            if query_params:
+                path = f"{path}?{urlencode(query_params)}"
+
+            ns_response = ns_session.post(path, json={})
+            ns_payload = ns_response.json()
+
+            ss_ref = self._get_or_create_reference(
+                StudysetReference, ns_payload.get("id")
+            )
+            new_studyset = Studyset(
+                user=current_user,
+                snapshot=deepcopy(source_studyset.snapshot)
+                if source_studyset.snapshot
+                else None,
+                version=source_studyset.version,
+                studyset_reference=ss_ref,
+            )
+            db.session.add(new_studyset)
+
+            source_annotation = getattr(source_project, "annotation", None)
+            annotations_payload = ns_payload.get("annotations") or []
+            annotation_id = None
+            if annotations_payload:
+                annotation_id = annotations_payload[0].get("id")
+            if source_annotation and copy_annotations and annotation_id:
+                annot_ref = self._get_or_create_reference(
+                    AnnotationReference, annotation_id
+                )
+                new_annotation = Annotation(
+                    user=current_user,
+                    snapshot=deepcopy(source_annotation.snapshot)
+                    if source_annotation.snapshot
+                    else None,
+                    annotation_reference=annot_ref,
+                    studyset=new_studyset,
+                )
+                db.session.add(new_annotation)
+
+        return new_studyset, new_annotation
+
+    def _clone_meta_analysis(
+        self, meta, user, project, new_studyset, new_annotation
+    ):
+        cloned_spec = self._clone_specification(meta.specification, user)
+        cloned_meta = MetaAnalysis(
+            name=meta.name,
+            description=meta.description,
+            specification=cloned_spec,
+            studyset=new_studyset,
+            annotation=new_annotation,
+            user=user,
+            project=project,
+            provenance=self._clone_meta_provenance(
+                meta.provenance,
+                new_studyset.studyset_reference.id if new_studyset else None,
+                new_annotation.annotation_reference.id if new_annotation else None,
+            ),
+        )
+
+        if new_studyset and new_studyset.studyset_reference:
+            cloned_meta.neurostore_studyset_id = new_studyset.studyset_reference.id
+            cloned_meta.cached_studyset = new_studyset
+
+        if new_annotation and new_annotation.annotation_reference:
+            cloned_meta.neurostore_annotation_id = new_annotation.annotation_reference.id
+            cloned_meta.cached_annotation = new_annotation
+
+        return cloned_meta
+
+    @staticmethod
+    def _clone_specification(specification, user):
+        if specification is None:
+            return None
+        cloned_spec = Specification(
+            type=specification.type,
+            estimator=deepcopy(specification.estimator),
+            database_studyset=specification.database_studyset,
+            filter=specification.filter,
+            corrector=deepcopy(specification.corrector),
+            user=user,
+        )
+        for spec_cond in specification.specification_conditions:
+            cloned_cond = SpecificationCondition(
+                weight=spec_cond.weight,
+                condition=spec_cond.condition,
+                user=user,
+            )
+            cloned_spec.specification_conditions.append(cloned_cond)
+        return cloned_spec
+
+    @staticmethod
+    def _clone_provenance(provenance, studyset_id, annotation_id):
+        if provenance is None:
+            return None
+        cloned = deepcopy(provenance)
+        extraction = cloned.get("extractionMetadata", {})
+        if studyset_id:
+            extraction["studysetId"] = studyset_id
+        if annotation_id:
+            extraction["annotationId"] = annotation_id
+        cloned["extractionMetadata"] = extraction
+
+        meta_meta = cloned.get("metaAnalysisMetadata")
+        if isinstance(meta_meta, dict):
+            meta_meta["canEditMetaAnalyses"] = True
+            cloned["metaAnalysisMetadata"] = meta_meta
+
+        return cloned
+
+    @staticmethod
+    def _clone_meta_provenance(provenance, studyset_id, annotation_id):
+        if provenance is None:
+            return None
+        cloned = deepcopy(provenance)
+        if studyset_id:
+            for key in ("studysetId", "studyset_id"):
+                if key in cloned:
+                    cloned[key] = studyset_id
+        if annotation_id:
+            for key in ("annotationId", "annotation_id"):
+                if key in cloned:
+                    cloned[key] = annotation_id
+        for key in ("hasResults", "has_results"):
+            if key in cloned:
+                cloned[key] = False
+        return cloned
+
+    @staticmethod
+    def _get_or_create_reference(model_cls, identifier):
+        if identifier is None:
+            return None
+        existing = db.session.execute(
+            select(model_cls).where(model_cls.id == identifier)
+        ).scalar_one_or_none()
+        if existing:
+            return existing
+        reference = model_cls(id=identifier)
+        db.session.add(reference)
+        return reference
 
 
 def create_neurovault_collection(nv_collection):

--- a/compose/backend/neurosynth_compose/resources/analysis.py
+++ b/compose/backend/neurosynth_compose/resources/analysis.py
@@ -711,7 +711,9 @@ class ProjectsView(ObjectView, ListView):
 
         source_id = clone_args.get("source_id")
         if source_id:
-            return self._clone_project(source_id, clone_args.get("copy_annotations", True))
+            return self._clone_project(
+                source_id, clone_args.get("copy_annotations", True)
+            )
 
         try:
             data = parser.parse(self.__class__._schema, request)
@@ -754,7 +756,10 @@ class ProjectsView(ObjectView, ListView):
         if source_project is None:
             abort(404)
 
-        if not source_project.public and source_project.user_id != current_user.external_id:
+        if (
+            not source_project.public
+            and source_project.user_id != current_user.external_id
+        ):
             abort(403, description="project is not public")
 
         access_token = request.headers.get("Authorization")
@@ -768,7 +773,9 @@ class ProjectsView(ObjectView, ListView):
                 client_secret=current_app.config["AUTH0_CLIENT_SECRET"],
                 audience=current_app.config["AUTH0_API_AUDIENCE"],
             )
-            access_token = " ".join([token_resp["token_type"], token_resp["access_token"]])
+            access_token = " ".join(
+                [token_resp["token_type"], token_resp["access_token"]]
+            )
 
         ns_session = neurostore_session(access_token)
 
@@ -858,9 +865,11 @@ class ProjectsView(ObjectView, ListView):
             )
             new_studyset = Studyset(
                 user=current_user,
-                snapshot=deepcopy(source_studyset.snapshot)
-                if source_studyset.snapshot
-                else None,
+                snapshot=(
+                    deepcopy(source_studyset.snapshot)
+                    if source_studyset.snapshot
+                    else None
+                ),
                 version=source_studyset.version,
                 studyset_reference=ss_ref,
             )
@@ -877,9 +886,11 @@ class ProjectsView(ObjectView, ListView):
                 )
                 new_annotation = Annotation(
                     user=current_user,
-                    snapshot=deepcopy(source_annotation.snapshot)
-                    if source_annotation.snapshot
-                    else None,
+                    snapshot=(
+                        deepcopy(source_annotation.snapshot)
+                        if source_annotation.snapshot
+                        else None
+                    ),
                     annotation_reference=annot_ref,
                     studyset=new_studyset,
                 )
@@ -887,9 +898,7 @@ class ProjectsView(ObjectView, ListView):
 
         return new_studyset, new_annotation
 
-    def _clone_meta_analysis(
-        self, meta, user, project, new_studyset, new_annotation
-    ):
+    def _clone_meta_analysis(self, meta, user, project, new_studyset, new_annotation):
         cloned_spec = self._clone_specification(meta.specification, user)
         cloned_meta = MetaAnalysis(
             name=meta.name,
@@ -911,7 +920,9 @@ class ProjectsView(ObjectView, ListView):
             cloned_meta.cached_studyset = new_studyset
 
         if new_annotation and new_annotation.annotation_reference:
-            cloned_meta.neurostore_annotation_id = new_annotation.annotation_reference.id
+            cloned_meta.neurostore_annotation_id = (
+                new_annotation.annotation_reference.id
+            )
             cloned_meta.cached_annotation = new_annotation
 
         return cloned_meta

--- a/compose/backend/neurosynth_compose/resources/analysis.py
+++ b/compose/backend/neurosynth_compose/resources/analysis.py
@@ -883,10 +883,7 @@ class ProjectsView(ObjectView, ListView):
                 )
                 new_annotation = Annotation(
                     user=current_user,
-                    snapshot=(
-                        deepcopy(source_annotation.snapshot)
-                        if source_annotation.snapshot
-                        else None
+                    snapshot=None
                     ),
                     annotation_reference=annot_ref,
                     studyset=new_studyset,

--- a/compose/backend/neurosynth_compose/resources/analysis.py
+++ b/compose/backend/neurosynth_compose/resources/analysis.py
@@ -785,7 +785,7 @@ class ProjectsView(ObjectView, ListView):
             )
 
             cloned_project = Project(
-                name=source_project.name,
+                name=source_project.name + "Copy",
                 description=source_project.description,
                 provenance=self._clone_provenance(
                     source_project.provenance,

--- a/compose/backend/neurosynth_compose/resources/analysis.py
+++ b/compose/backend/neurosynth_compose/resources/analysis.py
@@ -865,8 +865,7 @@ class ProjectsView(ObjectView, ListView):
             )
             new_studyset = Studyset(
                 user=current_user,
-                snapshot=None
-                ),
+                snapshot=None,
                 version=source_studyset.version,
                 studyset_reference=ss_ref,
             )
@@ -883,8 +882,7 @@ class ProjectsView(ObjectView, ListView):
                 )
                 new_annotation = Annotation(
                     user=current_user,
-                    snapshot=None
-                    ),
+                    snapshot=None,
                     annotation_reference=annot_ref,
                     studyset=new_studyset,
                 )

--- a/compose/backend/neurosynth_compose/resources/analysis.py
+++ b/compose/backend/neurosynth_compose/resources/analysis.py
@@ -865,10 +865,7 @@ class ProjectsView(ObjectView, ListView):
             )
             new_studyset = Studyset(
                 user=current_user,
-                snapshot=(
-                    deepcopy(source_studyset.snapshot)
-                    if source_studyset.snapshot
-                    else None
+                snapshot=None
                 ),
                 version=source_studyset.version,
                 studyset_reference=ss_ref,

--- a/compose/backend/neurosynth_compose/tests/api/test_project.py
+++ b/compose/backend/neurosynth_compose/tests/api/test_project.py
@@ -151,8 +151,14 @@ def test_clone_public_project_creates_new_project(
         .one()
     )
     assert cloned_project.user.external_id == auth_client.username
-    assert cloned_project.studyset_id and cloned_project.studyset_id != source_project.studyset_id
-    assert cloned_project.annotation_id and cloned_project.annotation_id != source_project.annotation_id
+    assert (
+        cloned_project.studyset_id
+        and cloned_project.studyset_id != source_project.studyset_id
+    )
+    assert (
+        cloned_project.annotation_id
+        and cloned_project.annotation_id != source_project.annotation_id
+    )
 
     expected_auth = f"Bearer {auth_client.token}"
     auth_headers = {

--- a/compose/backend/neurosynth_compose/tests/api/test_project.py
+++ b/compose/backend/neurosynth_compose/tests/api/test_project.py
@@ -2,6 +2,8 @@ from neurosynth_compose.models import Project, MetaAnalysisResult, User
 from neurosynth_compose.schemas import MetaAnalysisSchema
 from sqlalchemy import select
 
+from ..conftest import MockNeurostoreSession
+
 
 def test_get_all_projects(session, app, auth_client, user_data):
     projects = session.execute(select(Project)).scalars().all()
@@ -115,3 +117,107 @@ def test_search_capabilities(session, app, auth_client, user_data):
     search_term = "test"
     response = auth_client.get(f"/api/projects?search={search_term}")
     assert response.status_code == 200
+
+
+def test_clone_public_project_creates_new_project(
+    session, auth_client, user_data, reset_ns_session, mock_ns
+):
+    source_project = (
+        session.execute(
+            select(Project)
+            .join(Project.user)
+            .where(User.external_id != auth_client.username)
+            .where(Project.public == True)  # noqa: E712
+        )
+        .scalars()
+        .first()
+    )
+    assert source_project is not None
+
+    source_meta_ids = [ma.id for ma in source_project.meta_analyses]
+    response = auth_client.post(f"/api/projects?source_id={source_project.id}", data={})
+
+    assert response.status_code == 200
+    payload = response.json
+
+    assert payload["id"] != source_project.id
+    assert payload["user"] == auth_client.username
+    assert len(payload["meta_analyses"]) == len(source_meta_ids)
+    assert set(payload["meta_analyses"]) != set(source_meta_ids)
+
+    cloned_project = (
+        session.execute(select(Project).where(Project.id == payload["id"]))
+        .scalars()
+        .one()
+    )
+    assert cloned_project.user.external_id == auth_client.username
+    assert cloned_project.studyset_id and cloned_project.studyset_id != source_project.studyset_id
+    assert cloned_project.annotation_id and cloned_project.annotation_id != source_project.annotation_id
+
+    expected_auth = f"Bearer {auth_client.token}"
+    auth_headers = {
+        call["headers"].get("Authorization")
+        for call in MockNeurostoreSession.call_log
+        if call["method"] == "POST"
+    }
+    assert expected_auth in auth_headers
+
+
+def test_clone_private_project_forbidden(
+    session, auth_client, user_data, reset_ns_session, mock_ns
+):
+    private_project = (
+        session.execute(
+            select(Project)
+            .join(Project.user)
+            .where(User.external_id != auth_client.username)
+            .where(Project.public == False)  # noqa: E712
+        )
+        .scalars()
+        .first()
+    )
+    assert private_project is not None
+
+    resp = auth_client.post(f"/api/projects?source_id={private_project.id}", data={})
+
+    assert resp.status_code == 403
+
+
+def test_clone_public_project_without_annotations(
+    session, auth_client, user_data, reset_ns_session, mock_ns
+):
+    source_project = (
+        session.execute(
+            select(Project)
+            .join(Project.user)
+            .where(User.external_id != auth_client.username)
+            .where(Project.public == True)  # noqa: E712
+        )
+        .scalars()
+        .first()
+    )
+    assert source_project is not None
+    assert source_project.annotation is not None
+
+    response = auth_client.post(
+        f"/api/projects?source_id={source_project.id}&copy_annotations=false",
+        data={},
+    )
+
+    assert response.status_code == 200
+    payload = response.json
+    assert payload["annotation"] is None
+
+    cloned_project = (
+        session.execute(select(Project).where(Project.id == payload["id"]))
+        .scalars()
+        .one()
+    )
+    assert cloned_project.annotation_id is None
+
+    # ensure query parameter propagated
+    assert any(
+        call["path"].endswith("copy_annotations=false")
+        for call in MockNeurostoreSession.call_log
+        if call["method"] == "POST" and call["path"].startswith("/api/studysets")
+    )

--- a/compose/backend/neurosynth_compose/tests/conftest.py
+++ b/compose/backend/neurosynth_compose/tests/conftest.py
@@ -1,5 +1,8 @@
 from unittest.mock import patch
 
+import copy
+import itertools
+
 import flask_sqlalchemy
 import json
 from os.path import isfile
@@ -81,28 +84,101 @@ def mock_decode_token(token):
         return {"sub": "user2-id"}
 
 
-def mock_ns_session(request):
-    class MockResponse:
-        def __init__(self, data):
-            self.data = data
-            self.status_code = 200
+class MockResponse:
+    def __init__(self, data):
+        self.data = data
+        self.status_code = 200
 
-        def json(self):
-            return self.data
+    def json(self):
+        return self.data
 
-    class MockSession:
-        def post(self, path, json):
-            json.update({"id": "123"})
-            return MockResponse(json)
 
-        def put(self, path, json):
-            json.update({"id": path.split("/")[-1]})
-            return MockResponse(json)
+class MockNeurostoreSession:
+    """Lightweight stand-in for a requests.Session when mocking Neurostore."""
 
-        def get(self, path):
-            return MockResponse({"metadata": {"test": "value"}})
+    instances = []
+    call_log = []
+    _global_counter = itertools.count(10_000)
 
-    return MockSession()
+    def __init__(self):
+        self.headers = {}
+        self.calls = []
+        MockNeurostoreSession.instances.append(self)
+
+    @classmethod
+    def reset(cls):
+        cls.instances.clear()
+        cls.call_log.clear()
+        cls._global_counter = itertools.count(10_000)
+
+    @classmethod
+    def _next_id(cls, prefix):
+        return f"{prefix}-{next(cls._global_counter)}"
+
+    @staticmethod
+    def _extract_id(path):
+        return path.split("/")[-1]
+
+    def _record(self, method, path, payload=None):
+        call = {
+            "method": method,
+            "path": path,
+            "json": copy.deepcopy(payload),
+            "headers": dict(self.headers),
+        }
+        self.calls.append(call)
+        MockNeurostoreSession.call_log.append(call)
+
+    def _response_payload(self, path, payload):
+        data = copy.deepcopy(payload) if payload is not None else {}
+        if path.startswith("/api/studysets"):
+            data.setdefault("id", self._next_id("studyset"))
+            data.setdefault(
+                "annotations",
+                [
+                    {
+                        "id": self._next_id("annotation"),
+                        "studyset": data.get("id"),
+                    }
+                ],
+            )
+            return data
+        if path.startswith("/api/annotations"):
+            data.setdefault("id", self._next_id("annotation"))
+            return data
+        if path.startswith("/api/studies"):
+            data.setdefault("id", self._next_id("study"))
+            return data
+        data.setdefault("id", self._next_id("resource"))
+        return data
+
+    def post(self, path, json=None):
+        self._record("POST", path, json)
+        return MockResponse(self._response_payload(path, json))
+
+    def put(self, path, json=None):
+        payload = copy.deepcopy(json) if json is not None else {}
+        payload.setdefault("id", self._extract_id(path))
+        self._record("PUT", path, json)
+        return MockResponse(payload)
+
+    def get(self, path):
+        self._record("GET", path)
+        return MockResponse({"metadata": {"test": "value"}})
+
+
+def mock_ns_session(access_token):
+    session = MockNeurostoreSession()
+    if access_token:
+        session.headers.update({"Authorization": access_token})
+    return session
+
+
+@pytest.fixture(scope="function")
+def reset_ns_session():
+    MockNeurostoreSession.reset()
+    yield
+    MockNeurostoreSession.reset()
 
 
 class MockPYNVClient:
@@ -159,6 +235,9 @@ def mock_ns(monkeysession):
     """mock neurostore api"""
     monkeysession.setattr(
         "neurosynth_compose.resources.neurostore.neurostore_session", mock_ns_session
+    )
+    monkeysession.setattr(
+        "neurosynth_compose.resources.analysis.neurostore_session", mock_ns_session
     )
     # Remove patch for tasks, only patch neurostore.neurostore_session
 


### PR DESCRIPTION
closes #651 


`POST /api/projects/?source_id=<project_id>` will clone a project/studyset/annotations/specifications/meta-analyses for another user to make edits and decisions that may differ from the author of the project.