### PR TITLE
[FIX] make deploy to staging more robust

### DIFF
--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -84,8 +84,7 @@ jobs:
 
           # Wait for PostgreSQL to be ready
           until docker compose exec compose_pgsql pg_isready; do sleep 5; done
-
-           docker compose exec compose flask db upgrade
+          docker compose exec compose flask db upgrade
         '
 
     - name: Skip Docker commands and run frontend build if only frontend changes detected


### PR DESCRIPTION
simplify migrations so that we are not manipulating the database in a weird way re-writing history each time.