### PR TITLE
[REF] reduce time of non-nested studyset query

### DIFF
--- a/store/backend/neurostore/resources/data.py
+++ b/store/backend/neurostore/resources/data.py
@@ -213,7 +213,6 @@ class StudysetsView(ObjectView, ListView):
             )
         else:
             q = q.options(
-                selectinload(Studyset.studies).options(raiseload("*", sql_only=True)),
                 selectinload(Studyset.user)
                 .load_only(User.name, User.external_id)
                 .options(raiseload("*", sql_only=True)),


### PR DESCRIPTION
the output of pghero indicated this query was slow:
```
1 min 4%	583 ms	87postgres
SELECT studysets_1.id AS studysets_1_id, studies.name AS studies_name, studies.description AS studies_description, studies.publication AS studies_publication, studies.doi AS studies_doi, studies.pmid AS studies_pmid, studies.pmcid AS studies_pmcid, studies.authors AS studies_authors, studies.year AS studies_year, studies.public AS studies_public, studies.level AS studies_level, studies.metadata_ AS studies_metadata_, studies.source AS studies_source, studies.base_study_id AS studies_base_study_id, studies.source_id AS studies_source_id, studies.source_updated_at AS studies_source_updated_at, studies.user_id AS studies_user_id, studies.__ts_vector__ AS studies___ts_vector__, studies.id AS studies_id, studies.created_at AS studies_created_at, studies.updated_at AS studies_updated_at 
FROM studysets AS studysets_1 JOIN studyset_studies AS studyset_studies_1 ON studysets_1.id = studyset_studies_1.studyset_id JOIN studies ON studies.id = studyset_studies_1.study_id 
WHERE studysets_1.id IN ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)
```

This pull requests helps reduce the time of the studyset query.