### PR TITLE
[FIX] naming of containers

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -96,7 +96,7 @@ services:
       timeout: 3s
       retries: 10
 
-  pghero:
+  compose-pghero:
     image: ankane/pghero
     restart: always
     expose:
@@ -110,7 +110,7 @@ services:
       compose-pgsql17:
         condition: service_healthy
 
-  grafana:
+  compose-grafana:
     image: grafana/grafana
     restart: always
     expose:

--- a/compose/nginx/nginx.conf
+++ b/compose/nginx/nginx.conf
@@ -98,7 +98,7 @@ http {
 		}
 
 		location /pghero/ {
-			proxy_pass http://pghero:8080/pghero/;
+			proxy_pass http://compose-pghero:8080/pghero/;
 			proxy_set_header Host $host;
 			proxy_set_header X-Real-IP $remote_addr;
 			proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -110,7 +110,7 @@ http {
 
 		location /grafana/ {
 			rewrite ^/grafana/(.*)$ /$1 break;
-			proxy_pass http://grafana:3030/;
+			proxy_pass http://compose-grafana:3030/;
 			proxy_set_header Host $host;
 			proxy_set_header X-Real-IP $remote_addr;
 			proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/compose/nginx/nginx.dev.conf
+++ b/compose/nginx/nginx.dev.conf
@@ -99,7 +99,7 @@ http {
 		}
 
 		location /pghero/ {
-			proxy_pass http://pghero:8080/pghero/;
+			proxy_pass http://compose-pghero:8080/pghero/;
 			proxy_set_header Host $host;
 			proxy_set_header X-Real-IP $remote_addr;
 			proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -111,7 +111,7 @@ http {
 
 		location /grafana/ {
 			rewrite ^/grafana/(.*)$ /$1 break;
-			proxy_pass http://grafana:3030/;
+			proxy_pass http://compose-grafana:3030/;
 			proxy_set_header Host $host;
 			proxy_set_header X-Real-IP $remote_addr;
 			proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/store/backend/README.md
+++ b/store/backend/README.md
@@ -100,7 +100,7 @@ and execute:
 To start the pgHero service, ensure Docker Compose is set up and run:
 
 ```sh
-docker-compose up -d pghero
+docker-compose up -d store-pghero
 ```
 
 ### Accessing the pgHero Web UI

--- a/store/docker-compose.yml
+++ b/store/docker-compose.yml
@@ -87,7 +87,7 @@ services:
       timeout: 3s
       retries: 10
     
-  pghero:
+  store-pghero:
     image: ankane/pghero
     restart: always
     expose:
@@ -101,7 +101,7 @@ services:
       store-pgsql17:
         condition: service_healthy
 
-  grafana:
+  store-grafana:
     image: grafana/grafana
     restart: always
     expose:
@@ -132,4 +132,3 @@ networks:
   default:
     external:
       name: nginx-proxy
-

--- a/store/nginx/nginx.conf
+++ b/store/nginx/nginx.conf
@@ -94,7 +94,7 @@ http {
 		}
 
 		location /pghero/ {
-			proxy_pass http://pghero:8080/pghero/;
+			proxy_pass http://store-pghero:8080/pghero/;
 			proxy_set_header Host $host;
 			proxy_set_header X-Real-IP $remote_addr;
 			proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -106,7 +106,7 @@ http {
 	
 		location /grafana/ {
 			rewrite ^/grafana/(.*)$ /$1 break;
-			proxy_pass http://grafana:3030/;
+			proxy_pass http://store-grafana:3030/;
 			proxy_set_header Host $host;
 			proxy_set_header X-Real-IP $remote_addr;
 			proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
pghero and grafana had the same service name between compose and store resulting in unpredictable path resolution for the URIs, this fixes that conflict.