### PR TITLE
[FIX] missing analysis description in annotation table

### DIFF
--- a/compose/neurosynth-frontend/src/pages/Study/components/EditStudyAnnotationsHotTable.tsx
+++ b/compose/neurosynth-frontend/src/pages/Study/components/EditStudyAnnotationsHotTable.tsx
@@ -51,7 +51,6 @@ const EditStudyAnnotationsHotTable: React.FC<{ readonly?: boolean }> = ({ readon
                     [(colName as string).split('.')[1]]: newVal, // col names are given to us in the form "note.key"
                 },
             };
-            delete updatedNotes[row].analysisDescription;
         });
         updateNotes(updatedNotes);
     };


### PR DESCRIPTION
I noticed the analysis description was still disappearing when clicking on the annotation table (but not updating the analysis). Is there an issue with keeping the analysis description as an extra attribute? (or should the analysis description always be recomputed after an edit to the analysis OR annotation?). Assuming I understand the logic correctly... (that's a big IF)

addendum to #1283, don't delete the analysis description.