### PR TITLE
[FIX] allow studies to have non-existant source_ids without erroring out

### DIFF
--- a/store/backend/neurostore/resources/data.py
+++ b/store/backend/neurostore/resources/data.py
@@ -425,13 +425,17 @@ class StudysetsView(ObjectView, ListView):
         parent_source = getattr(record, "source", None)
         Model = type(record)
 
+        invalid_source_chain = False
         while parent_source_id is not None and parent_source == "neurostore":
-            source_id = parent_source_id
             parent = Model.query.filter_by(id=parent_source_id).first()
             if parent is None:
+                invalid_source_chain = True
                 break
+            source_id = parent_source_id
             parent_source_id = parent.source_id
             parent_source = getattr(parent, "source", None)
+        if invalid_source_chain:
+            return None
 
         return source_id
 
@@ -642,13 +646,18 @@ class AnnotationsView(ObjectView, ListView):
             abort_not_found(cls._model.__name__, source_id)
         parent_source_id = annotation.source_id
         parent_source = annotation.source
+        invalid_source_chain = False
         while parent_source_id is not None and parent_source == "neurostore":
-            source_id = parent_source_id
-            parent = cls._model.query.filter_by(id=source_id).first()
+            parent = cls._model.query.filter_by(id=parent_source_id).first()
             if parent is None:
-                abort_not_found(cls._model.__name__, source_id)
+                # Orphaned source_id: mark invalid and stop traversal.
+                invalid_source_chain = True
+                break
+            source_id = parent_source_id
             parent_source = parent.source
             parent_source_id = parent.source_id
+        if invalid_source_chain:
+            source_id = None
 
         context = {
             "clone": True,
@@ -1959,13 +1968,18 @@ class StudiesView(ObjectView, ListView):
             abort_not_found(cls._model.__name__, source_id)
         parent_source_id = study.source_id
         parent_source = study.source
+        invalid_source_chain = False
         while parent_source_id is not None and parent_source == "neurostore":
-            source_id = parent_source_id
-            parent = cls._model.query.filter_by(id=source_id).first()
+            parent = cls._model.query.filter_by(id=parent_source_id).first()
             if parent is None:
-                abort_not_found(cls._model.__name__, source_id)
+                # Orphaned source_id: mark invalid and stop traversal.
+                invalid_source_chain = True
+                break
+            source_id = parent_source_id
             parent_source = parent.source
             parent_source_id = parent.source_id
+        if invalid_source_chain:
+            source_id = None
 
         update_schema = cls._schema(context={"nested": True})
         clone_data = update_schema.load(update_schema.dump(study))
@@ -1991,6 +2005,10 @@ class StudiesView(ObjectView, ListView):
 
     def pre_nested_record_update(record):
         """Find/create the associated base study"""
+        if record.source == "neurostore" and record.source_id:
+            parent = Study.query.filter_by(id=record.source_id).first()
+            if parent is None:
+                record.source_id = None
         # if the study was cloned and the base_study is already known.
         if record.base_study_id is not None or record.base_study is not None:
             return record


### PR DESCRIPTION
if the source_id from a study was a neurostore_id and the original study from which that study was cloned was deleted, then any subsequent clones would fail since the chain was broken. This makes it so that you can still edit/clone cloned studies even if a parent was deleted at some point.