### PR TITLE
[FIX] project result viewing

### DIFF
--- a/compose/neurosynth-frontend/src/pages/Project/components/ProjectViewMetaAnalysis.tsx
+++ b/compose/neurosynth-frontend/src/pages/Project/components/ProjectViewMetaAnalysis.tsx
@@ -1,9 +1,9 @@
 import { Alert, Box, Button, Card, CardActions, CardContent, Chip, Typography } from '@mui/material';
 import StateHandlerComponent from 'components/StateHandlerComponent/StateHandlerComponent';
-import { getResultStatus } from 'helpers/MetaAnalysis.helpers';
+import { getLatestMetaAnalysisResultId, getResultStatus } from 'helpers/MetaAnalysis.helpers';
 import { useGetMetaAnalysisResultById } from 'hooks';
 import useUserCanEdit from 'hooks/useUserCanEdit';
-import { MetaAnalysisReturn, ResultReturn } from 'neurosynth-compose-typescript-sdk';
+import { MetaAnalysisReturn } from 'neurosynth-compose-typescript-sdk';
 import useGetMetaAnalysisJobById from 'pages/MetaAnalysis/hooks/useGetMetaAnalysisJobById';
 import useGetMetaAnalysisJobsByMetaAnalysisId from 'pages/MetaAnalysis/hooks/useGetMetaAnalysisJobsByMetaAnalysisId';
 import { useProjectUser } from 'pages/Project/store/ProjectStore';
@@ -26,13 +26,12 @@ const ProjectViewMetaAnalysis: React.FC<MetaAnalysisReturn> = (props) => {
         isLoading: latestJobIsLoading,
         isError: latestJobIsError,
     } = useGetMetaAnalysisJobById(latestJob?.job_id, canEdit);
-    const allResults = (props.results ?? []) as ResultReturn[];
-    const latestResult = allResults.length > 0 ? allResults[allResults.length - 1] : undefined;
+    const latestResultId = getLatestMetaAnalysisResultId(props);
     const {
         data: metaAnalysisResult,
         isLoading: getMetaAnalysisResultIsLoading,
         isError: getMetaAnalysisResultIsError,
-    } = useGetMetaAnalysisResultById(latestResult?.id);
+    } = useGetMetaAnalysisResultById(latestResultId);
 
     const navigate = useNavigate();
 

--- a/compose/neurosynth-frontend/src/pages/Projects/components/ProjectsPageCardSummaryMetaAnalysesListItem.tsx
+++ b/compose/neurosynth-frontend/src/pages/Projects/components/ProjectsPageCardSummaryMetaAnalysesListItem.tsx
@@ -1,7 +1,7 @@
 import { ListItem, ListItemButton, ListItemIcon, ListItemProps, ListItemText, Skeleton } from '@mui/material';
-import { getResultStatus } from 'helpers/MetaAnalysis.helpers';
+import { getLatestMetaAnalysisResultId, getResultStatus } from 'helpers/MetaAnalysis.helpers';
 import { useGetMetaAnalysisResultById } from 'hooks';
-import { MetaAnalysisReturn, ResultReturn } from 'neurosynth-compose-typescript-sdk';
+import { MetaAnalysisReturn } from 'neurosynth-compose-typescript-sdk';
 import useGetMetaAnalysisJobById from 'pages/MetaAnalysis/hooks/useGetMetaAnalysisJobById';
 import useGetMetaAnalysisJobsByMetaAnalysisId from 'pages/MetaAnalysis/hooks/useGetMetaAnalysisJobsByMetaAnalysisId';
 import { useMemo } from 'react';
@@ -11,11 +11,10 @@ const ProjectsPageCardSummaryMetaAnalysesListItem: React.FC<ListItemProps & { me
     props
 ) => {
     const { metaAnalysis, ...listItemProps } = props;
+    const latestResultId = getLatestMetaAnalysisResultId(metaAnalysis);
 
     const { data: metaAnalysisResult, isLoading: getMetaAnalysisResultIsLoading } = useGetMetaAnalysisResultById(
-        metaAnalysis?.results && metaAnalysis.results.length
-            ? (metaAnalysis.results[metaAnalysis.results.length - 1] as ResultReturn).id
-            : undefined
+        latestResultId
     );
 
     const { data: metaAnalysisJobs, isLoading: metaAnalysisJobsIsLoading } = useGetMetaAnalysisJobsByMetaAnalysisId(


### PR DESCRIPTION
since meta-analysis is not nested anymore, request is sent directly to the meta-analysis-result endpoint.