### PR TITLE
[ENH] syncronize versions with release

### DIFF
--- a/.github/workflows/release-sync.yml
+++ b/.github/workflows/release-sync.yml
@@ -1,0 +1,83 @@
+name: Release Metadata Sync
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to sync, for example v0.17.4"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  sync_or_verify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref }}
+
+      - name: Resolve tag and mode
+        id: release
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+            echo "mode=write" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+            echo "mode=check" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Sync release metadata
+        shell: bash
+        run: |
+          cmd=(python3 scripts/release/sync_release_metadata.py --tag "${{ steps.release.outputs.tag }}")
+          if [ "${{ steps.release.outputs.mode }}" = "check" ]; then
+            cmd+=(--check)
+          fi
+          "${cmd[@]}"
+
+      - name: Commit synced metadata
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        shell: bash
+        run: |
+          if git diff --quiet; then
+            echo "No release metadata changes to commit."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add codemeta.json .zenodo.json store/backend/pyproject.toml compose/backend/pyproject.toml compose/neurosynth-frontend/package.json
+          git commit -m "Sync release metadata for ${{ steps.release.outputs.tag }}"
+          git push
+
+      - name: Create and push tag
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        shell: bash
+        run: |
+          tag="${{ steps.release.outputs.tag }}"
+
+          if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+            echo "Tag ${tag} already exists locally." >&2
+            exit 1
+          fi
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
+            echo "Tag ${tag} already exists on origin." >&2
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${tag}" -m "${tag}"
+          git push origin "${tag}"

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,15 +1,16 @@
 {
+  "title": "Neurosynth Compose",
   "creators": [
     {
       "affiliation": "University of Texas at Austin",
       "orcid": "0000-0002-4892-2659",
       "name": "James Kent"
     },
-     {
+    {
       "affiliation": "University of Texas at Austin",
       "name": "Yarkoni, Tal",
       "orcid": "0000-0002-6558-5113"
-     },
+    },
     {
       "affiliation": "University of Texas at Austin",
       "name": "De La Vega, Alejandro",
@@ -19,12 +20,13 @@
       "affiliation": "McGill University",
       "name": "Lee, Nicholas",
       "orcid": "0009-0000-7088-310X"
-    } 
+    }
   ],
   "keywords": [
     "neuroimaging",
     "meta-analysis",
     "fMRI"
   ],
-  "upload_type": "software"
+  "upload_type": "software",
+  "version": "0.18.2"
 }

--- a/codemeta.json
+++ b/codemeta.json
@@ -54,7 +54,7 @@
     "dateModified": "2026-04-21",
     "datePublished": "2022-09-07",
     "description": "Platform for representing summary data from studies and methods to synthesize the data (typically a meta-analysis)",
-    "downloadUrl": "https://github.com/neurostuff/neurostore/archive/refs/tags/v0.18.1.tar.gz",
+    "downloadUrl": "https://github.com/neurostuff/neurostore/archive/refs/tags/v0.18.2.tar.gz",
     "funder": {
         "type": "Organization",
         "name": "National Institutes of Health"
@@ -107,7 +107,7 @@
         "https://neurostuff.github.io/"
     ],
     "runtimePlatform": "Docker Compose",
-    "version": "0.18.1",
+    "version": "0.18.2",
     "codemeta:contIntegration": {
         "id": "https://github.com/neurostuff/neurostore/actions"
     },

--- a/compose/backend/pyproject.toml
+++ b/compose/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "neurosynth_compose"
-version = "0.10.0"
+version = "0.18.2"
 description = "neurosynth compose"
 authors = [
     { name="James Kent", email="jamesdkent21@gmail.com" }

--- a/compose/neurosynth-frontend/package.json
+++ b/compose/neurosynth-frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "neurosynth",
-    "version": "0.1.0",
+    "version": "0.18.2",
     "private": true,
     "dependencies": {
         "@auth0/auth0-react": "^1.6.0",

--- a/scripts/release/sync_release_metadata.py
+++ b/scripts/release/sync_release_metadata.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Sync release metadata files from a canonical Git tag."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TAG_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Sync release metadata files from a Git tag."
+    )
+    parser.add_argument(
+        "--tag",
+        help="Release tag to sync from, for example v0.17.4. "
+        "Defaults to the exact tag at HEAD.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Do not write files; exit non-zero if changes would be made.",
+    )
+    return parser.parse_args()
+
+
+def git(*args: str) -> str:
+    return subprocess.check_output(
+        ["git", *args],
+        cwd=REPO_ROOT,
+        text=True,
+    ).strip()
+
+
+def resolve_tag(explicit_tag: str | None) -> str:
+    if explicit_tag:
+        tag = explicit_tag.strip()
+    else:
+        try:
+            tag = git("describe", "--tags", "--exact-match")
+        except subprocess.CalledProcessError as exc:
+            raise SystemExit(
+                "No tag provided and HEAD is not at an exact tag. "
+                "Pass --tag <release-tag>."
+            ) from exc
+
+    if not TAG_RE.match(tag):
+        raise SystemExit(f"Unsupported tag format: {tag!r}")
+
+    return tag
+
+
+def version_from_tag(tag: str) -> str:
+    return tag[1:] if tag.startswith("v") else tag
+
+
+def update_json(path: Path, transform, indent: int) -> bool:
+    before = path.read_text()
+    data = json.loads(before)
+    updated = transform(data)
+    after = json.dumps(updated, indent=indent) + "\n"
+    if after == before:
+        return False
+    path.write_text(after)
+    return True
+
+
+def update_text_version(path: Path, version: str) -> bool:
+    before = path.read_text()
+    after, count = re.subn(
+        r'(^version\s*=\s*")[^"]+(")',
+        rf"\g<1>{version}\2",
+        before,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    if count != 1:
+        raise SystemExit(f"Could not find a top-level version field in {path}")
+    if after == before:
+        return False
+    path.write_text(after)
+    return True
+
+
+def sync_codemeta(version: str, tag: str, check: bool) -> bool:
+    path = REPO_ROOT / "codemeta.json"
+
+    def transform(data: dict) -> dict:
+        data["version"] = version
+        data["downloadUrl"] = (
+            f"https://github.com/neurostuff/neurostore/archive/refs/tags/{tag}.tar.gz"
+        )
+        return data
+
+    return apply_change(path, lambda: update_json(path, transform, indent=4), check)
+
+
+def sync_zenodo(version: str, check: bool) -> bool:
+    path = REPO_ROOT / ".zenodo.json"
+
+    def transform(data: dict) -> dict:
+        data["version"] = version
+        return data
+
+    return apply_change(path, lambda: update_json(path, transform, indent=2), check)
+
+
+def sync_package_json(version: str, check: bool) -> bool:
+    path = REPO_ROOT / "compose" / "neurosynth-frontend" / "package.json"
+
+    def transform(data: dict) -> dict:
+        data["version"] = version
+        return data
+
+    return apply_change(path, lambda: update_json(path, transform, indent=4), check)
+
+
+def apply_change(path: Path, writer, check: bool) -> bool:
+    if check:
+        before = path.read_text()
+        writer()
+        after = path.read_text()
+        path.write_text(before)
+        return after != before
+    return writer()
+
+
+def main() -> int:
+    args = parse_args()
+    tag = resolve_tag(args.tag)
+    version = version_from_tag(tag)
+
+    changed_paths: list[str] = []
+
+    if sync_codemeta(version, tag, args.check):
+        changed_paths.append("codemeta.json")
+    if sync_zenodo(version, args.check):
+        changed_paths.append(".zenodo.json")
+    if apply_change(
+        REPO_ROOT / "store" / "backend" / "pyproject.toml",
+        lambda: update_text_version(
+            REPO_ROOT / "store" / "backend" / "pyproject.toml", version
+        ),
+        args.check,
+    ):
+        changed_paths.append("store/backend/pyproject.toml")
+    if apply_change(
+        REPO_ROOT / "compose" / "backend" / "pyproject.toml",
+        lambda: update_text_version(
+            REPO_ROOT / "compose" / "backend" / "pyproject.toml", version
+        ),
+        args.check,
+    ):
+        changed_paths.append("compose/backend/pyproject.toml")
+    if sync_package_json(version, args.check):
+        changed_paths.append("compose/neurosynth-frontend/package.json")
+
+    if args.check:
+        if changed_paths:
+            print(
+                "Release metadata is out of sync for tag "
+                f"{tag}: {', '.join(changed_paths)}",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"Release metadata already matches {tag}.")
+        return 0
+
+    if changed_paths:
+        print(f"Synced release metadata to {tag}: {', '.join(changed_paths)}")
+    else:
+        print(f"Release metadata already matches {tag}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/store/backend/pyproject.toml
+++ b/store/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "neurostore"
-version = "0.10.0"
+version = "0.18.2"
 description = "neurostore"
 authors = [
     { name = "James Kent", email = "jamesdkent21@gmail.com" }


### PR DESCRIPTION
the versions of the packages and metadata are out of sync/can drift from release to release, this helps keep that information all together.