### PR TITLE
fix: prevent user from being stuck in sign in or log in loop

### DIFF
--- a/compose/neurosynth-frontend/__mocks__/@auth0/auth0-react.ts
+++ b/compose/neurosynth-frontend/__mocks__/@auth0/auth0-react.ts
@@ -1,5 +1,16 @@
 import { vi } from 'vitest';
 
+/**
+ * Mirrors @auth0/auth0-react so instanceof checks in app code work when the module is mocked.
+ * @see https://github.com/auth0/auth0-react/blob/master/src/errors.tsx
+ */
+export class OAuthError extends Error {
+    constructor(public error: string, public error_description?: string) {
+        super(error_description || error);
+        Object.setPrototypeOf(this, OAuthError.prototype);
+    }
+}
+
 const useAuth0 = vi.fn().mockReturnValue({
     getAccessTokenSilently: vi.fn().mockImplementation(() => {
         return Promise.resolve('test-token');

--- a/compose/neurosynth-frontend/src/api/__mocks__/index.ts
+++ b/compose/neurosynth-frontend/src/api/__mocks__/index.ts
@@ -1,0 +1,3 @@
+import { vi } from 'vitest';
+
+export const initAPISetAccessTokenFunc = vi.fn();

--- a/compose/neurosynth-frontend/src/hooks/useAuthenticate.spec.tsx
+++ b/compose/neurosynth-frontend/src/hooks/useAuthenticate.spec.tsx
@@ -1,0 +1,210 @@
+import { OAuthError, useAuth0 } from '@auth0/auth0-react';
+import { initAPISetAccessTokenFunc } from 'api';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useSnackbar } from 'notistack';
+import { useNavigate } from 'react-router-dom';
+import { vi, type Mock } from 'vitest';
+import useAuthenticate from './useAuthenticate';
+
+/** Must match `AUTH0_FORCE_PROMPT_LOGIN_KEY` in useAuthenticate.tsx */
+const AUTH0_FORCE_PROMPT_LOGIN_KEY = 'neurosynth_auth0_force_prompt_login';
+
+vi.mock('@auth0/auth0-react');
+vi.mock('notistack');
+vi.mock('react-router-dom');
+vi.mock('api');
+
+const enqueueSnackbarMock = () => (useSnackbar() as unknown as { enqueueSnackbar: Mock }).enqueueSnackbar;
+
+const LoginHarness = () => {
+    const { handleLogin, handleLogout } = useAuthenticate();
+    return (
+        <div>
+            <button type="button" data-testid="login" onClick={() => void handleLogin()}>
+                login
+            </button>
+            <button type="button" data-testid="logout" onClick={() => handleLogout()}>
+                logout
+            </button>
+        </div>
+    );
+};
+
+describe('useAuthenticate', () => {
+    const expectedAudience = import.meta.env.VITE_APP_AUTH0_AUDIENCE;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        sessionStorage.clear();
+        delete (window as unknown as { gtag?: (...args: unknown[]) => void }).gtag;
+    });
+
+    describe('handleLogin', () => {
+        it('calls Auth0 popup with audience and scope, wires API token helper, navigates home, and clears force-login flag on success', async () => {
+            sessionStorage.setItem(AUTH0_FORCE_PROMPT_LOGIN_KEY, '1');
+            (useAuth0().getAccessTokenWithPopup as Mock).mockResolvedValue('token');
+
+            render(<LoginHarness />);
+
+            await act(async () => {
+                userEvent.click(screen.getByTestId('login'));
+            });
+
+            expect(sessionStorage.getItem(AUTH0_FORCE_PROMPT_LOGIN_KEY)).toBeNull();
+            expect(useAuth0().getAccessTokenWithPopup as Mock).toHaveBeenCalledWith({
+                audience: expectedAudience,
+                scope: 'openid profile email offline_access',
+                prompt: 'login',
+            });
+            expect(initAPISetAccessTokenFunc).toHaveBeenCalledWith(useAuth0().getAccessTokenSilently as Mock);
+            expect(useNavigate() as Mock).toHaveBeenCalledWith('/');
+            expect(enqueueSnackbarMock()).not.toHaveBeenCalled();
+        });
+
+        it('does not pass prompt=login when session flag is absent', async () => {
+            (useAuth0().getAccessTokenWithPopup as Mock).mockResolvedValue('token');
+
+            render(<LoginHarness />);
+
+            await act(async () => {
+                userEvent.click(screen.getByTestId('login'));
+            });
+
+            expect(useAuth0().getAccessTokenWithPopup as Mock).toHaveBeenCalledWith({
+                audience: expectedAudience,
+                scope: 'openid profile email offline_access',
+            });
+        });
+
+        it('fires gtag login event when window.gtag exists', async () => {
+            const gtag = vi.fn();
+            (window as unknown as { gtag: typeof gtag }).gtag = gtag;
+            (useAuth0().getAccessTokenWithPopup as Mock).mockResolvedValue('token');
+
+            render(<LoginHarness />);
+
+            await act(async () => {
+                userEvent.click(screen.getByTestId('login'));
+            });
+
+            expect(gtag).toHaveBeenCalledWith('event', 'login');
+        });
+
+        it('sets session flag and warning snackbar on access_denied (OAuthError)', async () => {
+            (useAuth0().getAccessTokenWithPopup as Mock).mockRejectedValue(
+                new OAuthError('access_denied', 'user denied')
+            );
+
+            render(<LoginHarness />);
+
+            await act(async () => {
+                userEvent.click(screen.getByTestId('login'));
+            });
+
+            expect(sessionStorage.getItem(AUTH0_FORCE_PROMPT_LOGIN_KEY)).toBe('1');
+            expect(enqueueSnackbarMock()).toHaveBeenCalledWith('Sign in/Sign up cancelled', { variant: 'warning' });
+            expect(useNavigate() as Mock).not.toHaveBeenCalled();
+            expect(initAPISetAccessTokenFunc).not.toHaveBeenCalled();
+        });
+
+        it('sets session flag and no snackbar on popup cancelled (OAuthError cancelled)', async () => {
+            (useAuth0().getAccessTokenWithPopup as Mock).mockRejectedValue(new OAuthError('cancelled', 'popup closed'));
+
+            render(<LoginHarness />);
+
+            await act(async () => {
+                userEvent.click(screen.getByTestId('login'));
+            });
+
+            expect(sessionStorage.getItem(AUTH0_FORCE_PROMPT_LOGIN_KEY)).toBe('1');
+            expect(enqueueSnackbarMock()).not.toHaveBeenCalled();
+            expect(useNavigate() as Mock).not.toHaveBeenCalled();
+        });
+
+        it('does not set session flag on generic Error (e.g. legacy Popup closed message)', async () => {
+            (useAuth0().getAccessTokenWithPopup as Mock).mockRejectedValue(new Error('Popup closed'));
+
+            render(<LoginHarness />);
+
+            await act(async () => {
+                userEvent.click(screen.getByTestId('login'));
+            });
+
+            expect(sessionStorage.getItem(AUTH0_FORCE_PROMPT_LOGIN_KEY)).toBeNull();
+            expect(enqueueSnackbarMock()).toHaveBeenCalledWith('Sign in/Sign up Error', { variant: 'error' });
+        });
+
+        it('does not set session flag on OAuthError other than access_denied or cancelled', async () => {
+            (useAuth0().getAccessTokenWithPopup as Mock).mockRejectedValue(
+                new OAuthError('login_required', 'silent auth failed')
+            );
+
+            render(<LoginHarness />);
+
+            await act(async () => {
+                userEvent.click(screen.getByTestId('login'));
+            });
+
+            expect(sessionStorage.getItem(AUTH0_FORCE_PROMPT_LOGIN_KEY)).toBeNull();
+            expect(enqueueSnackbarMock()).toHaveBeenCalledWith('Sign in/Sign up Error', { variant: 'error' });
+        });
+
+        it('does not set session flag on non-OAuth thrown value', async () => {
+            (useAuth0().getAccessTokenWithPopup as Mock).mockRejectedValue('string failure');
+
+            render(<LoginHarness />);
+
+            await act(async () => {
+                userEvent.click(screen.getByTestId('login'));
+            });
+
+            expect(sessionStorage.getItem(AUTH0_FORCE_PROMPT_LOGIN_KEY)).toBeNull();
+            expect(enqueueSnackbarMock()).toHaveBeenCalledWith('Sign in/Sign up Error', { variant: 'error' });
+        });
+
+        it('forces login after access_denied sending prompt=login', async () => {
+            (useAuth0().getAccessTokenWithPopup as Mock)
+                .mockRejectedValueOnce(new OAuthError('access_denied', 'denied'))
+                .mockResolvedValueOnce('token');
+
+            render(<LoginHarness />);
+
+            await act(async () => {
+                userEvent.click(screen.getByTestId('login'));
+            });
+            expect(sessionStorage.getItem(AUTH0_FORCE_PROMPT_LOGIN_KEY)).toBe('1');
+
+            await act(async () => {
+                userEvent.click(screen.getByTestId('login'));
+            });
+
+            expect(useAuth0().getAccessTokenWithPopup as Mock).toHaveBeenNthCalledWith(2, {
+                audience: expectedAudience,
+                scope: 'openid profile email offline_access',
+                prompt: 'login',
+            });
+            expect(sessionStorage.getItem(AUTH0_FORCE_PROMPT_LOGIN_KEY)).toBeNull();
+            expect(useNavigate() as Mock).toHaveBeenCalledWith('/');
+        });
+    });
+
+    describe('handleLogout', () => {
+        it('calls Auth0 logout with returnTo origin', () => {
+            render(<LoginHarness />);
+
+            userEvent.click(screen.getByTestId('logout'));
+
+            expect(useAuth0().logout as Mock).toHaveBeenCalledWith({ returnTo: window.location.origin });
+        });
+    });
+
+    describe('useAuth0 wiring', () => {
+        it('reads auth helpers from useAuth0', () => {
+            render(<LoginHarness />);
+            expect(useAuth0).toHaveBeenCalled();
+            expect(useSnackbar).toHaveBeenCalled();
+            expect(useNavigate).toHaveBeenCalled();
+        });
+    });
+});

--- a/compose/neurosynth-frontend/src/hooks/useAuthenticate.tsx
+++ b/compose/neurosynth-frontend/src/hooks/useAuthenticate.tsx
@@ -1,9 +1,22 @@
-import { useAuth0 } from '@auth0/auth0-react';
+import { OAuthError, useAuth0 } from '@auth0/auth0-react';
 import { initAPISetAccessTokenFunc } from 'api';
 import { useSnackbar } from 'notistack';
 import { useNavigate } from 'react-router-dom';
 
 const AUTH0_AUDIENCE = import.meta.env.VITE_APP_AUTH0_AUDIENCE;
+
+/** When set, the next popup uses prompt=login so Universal Login restarts (e.g. pick another IdP after closing on consent). */
+const AUTH0_FORCE_PROMPT_LOGIN_KEY = 'neurosynth_auth0_force_prompt_login';
+
+function isAuth0AccessDenied(error: unknown): boolean {
+    if (typeof error !== 'object' || error === null) return false;
+    return error instanceof OAuthError && error.error === 'access_denied';
+}
+
+function isAuth0PopupClosed(error: unknown): boolean {
+    if (typeof error !== 'object' || error === null) return false;
+    return error instanceof OAuthError && error.error === 'cancelled';
+}
 
 function useAuthenticate() {
     const { enqueueSnackbar } = useSnackbar();
@@ -11,11 +24,16 @@ function useAuthenticate() {
     const { getAccessTokenWithPopup, getAccessTokenSilently, logout } = useAuth0();
 
     const handleLogin = async () => {
+        const forcePromptLogin = sessionStorage.getItem(AUTH0_FORCE_PROMPT_LOGIN_KEY) === '1';
+
         try {
             await getAccessTokenWithPopup({
                 audience: AUTH0_AUDIENCE,
                 scope: 'openid profile email offline_access',
+                ...(forcePromptLogin ? { prompt: 'login' as const } : {}),
             });
+
+            sessionStorage.removeItem(AUTH0_FORCE_PROMPT_LOGIN_KEY);
 
             initAPISetAccessTokenFunc(getAccessTokenSilently);
 
@@ -25,13 +43,17 @@ function useAuthenticate() {
 
             navigate('/');
         } catch (error) {
-            if (error instanceof Error && error.message === 'Popup closed') {
-                console.error('Error getting token:', error.message);
-                enqueueSnackbar(error.message, { variant: 'warning' });
+            if (isAuth0PopupClosed(error) || isAuth0AccessDenied(error)) {
+                sessionStorage.setItem(AUTH0_FORCE_PROMPT_LOGIN_KEY, '1');
+            }
+
+            if (isAuth0AccessDenied(error)) {
+                enqueueSnackbar('Sign in/Sign up cancelled', { variant: 'warning' });
+                return;
+            } else if (!isAuth0PopupClosed(error)) {
+                enqueueSnackbar('Sign in/Sign up Error', { variant: 'error' });
                 return;
             }
-            console.error('Error getting token:', error);
-            enqueueSnackbar('Error logging in', { variant: 'error' });
         }
     };
 


### PR DESCRIPTION
This PR resolves a minor bug I found when logging in. If users log in or sign up for the first time, they are prompted by auth0 to authorize our app to access their email. However, if a user then wants to decline or cancel this by closing the window, all subsequent login/sign up attempts will just bring them back to the authorize page and they will be unable to switch their mode of login.

This PR fixes this issue by settings a flag on login. On successful login, the flag is removed.
If we detect that the user has cancelled the login (error === "access_denied" or error === "cancelled"), then we will force auth0 to show the login page again, thus allowing the user to select a different method of logging in if they so desire.