### PR TITLE
[REF] move more error handling to connexion/asgi

### DIFF
--- a/compose/backend/neurosynth_compose/__init__.py
+++ b/compose/backend/neurosynth_compose/__init__.py
@@ -4,16 +4,23 @@ from pathlib import Path
 import connexion
 from authlib.integrations.flask_client import OAuth
 from connexion.exceptions import OAuthProblem
+from connexion.exceptions import ProblemException
 from connexion.resolver import MethodResolver
 from flask import Response, request
 from flask_admin import Admin, AdminIndexView
 from flask_admin.contrib.sqla import ModelView
 from flask_admin.theme import Bootstrap4Theme
 from flask_orjson import OrjsonProvider
+from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.middleware.cors import CORSMiddleware
 
 from neurosynth_compose.config import resolve_config_object
 from neurosynth_compose.database import init_db
+from neurosynth_compose.resources.errors import (
+    general_exception_handler,
+    http_exception_handler,
+    problem_exception_handler,
+)
 from neurosynth_compose.resources.auth import asgi_oauth_problem_handler
 from neurosynth_compose.resources.auth import init_app as init_auth
 
@@ -175,10 +182,10 @@ def create_app():
 
     app.secret_key = app.config["JWT_SECRET_KEY"]
 
-    connexion_app.exception_handlers = {
-        **getattr(connexion_app, "exception_handlers", {}),
-        OAuthProblem: asgi_oauth_problem_handler,
-    }
+    connexion_app.add_error_handler(OAuthProblem, asgi_oauth_problem_handler)
+    connexion_app.add_error_handler(ProblemException, problem_exception_handler)
+    connexion_app.add_error_handler(StarletteHTTPException, http_exception_handler)
+    connexion_app.add_error_handler(Exception, general_exception_handler)
 
     cors_asgi_app = CORSMiddleware(connexion_app, **cors_kwargs)
 

--- a/compose/backend/neurosynth_compose/resources/auth.py
+++ b/compose/backend/neurosynth_compose/resources/auth.py
@@ -3,11 +3,11 @@ from contextlib import contextmanager
 from urllib.request import urlopen
 
 from connexion.exceptions import OAuthProblem
+from connexion.lifecycle import ConnexionResponse
 from connexion.security import NO_VALUE
 from flask import current_app, has_app_context
 from jose import jwt
 from sqlalchemy import select
-from starlette.responses import JSONResponse
 from werkzeug.local import LocalProxy
 
 from neurosynth_compose.database import db
@@ -17,29 +17,20 @@ def _oauth_problem(detail):
     return OAuthProblem(detail=detail)
 
 
-def _apply_cors_headers(response, origin=None):
-    response.headers["Access-Control-Allow-Origin"] = origin or "*"
-    response.headers["Access-Control-Allow-Methods"] = "*"
-    response.headers["Access-Control-Allow-Headers"] = "*"
-    response.headers["Access-Control-Allow-Credentials"] = "true"
-    if origin:
-        response.headers["Vary"] = "Origin"
-    return response
-
-
 async def asgi_oauth_problem_handler(request, exc):
     status_code = getattr(exc, "status_code", 401)
-    response = JSONResponse(
-        {
-            "type": "about:blank",
-            "title": "Unauthorized" if status_code == 401 else "Error",
-            "detail": getattr(exc, "detail", str(exc)),
-            "status": status_code,
-        },
+    return ConnexionResponse(
+        body=json.dumps(
+            {
+                "type": "about:blank",
+                "title": "Unauthorized" if status_code == 401 else "Error",
+                "detail": getattr(exc, "detail", str(exc)),
+                "status": status_code,
+            }
+        ),
         status_code=status_code,
-        media_type="application/problem+json",
+        mimetype="application/json",
     )
-    return _apply_cors_headers(response, request.headers.get("origin"))
 
 
 _flask_app = None

--- a/compose/backend/neurosynth_compose/resources/errors.py
+++ b/compose/backend/neurosynth_compose/resources/errors.py
@@ -1,0 +1,64 @@
+import json
+import logging
+
+import anyio
+from connexion.exceptions import ProblemException
+from connexion.lifecycle import ConnexionResponse
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+logger = logging.getLogger(__name__)
+
+
+def _json_response(
+    body: dict, status_code: int, headers: dict | None = None
+) -> ConnexionResponse:
+    return ConnexionResponse(
+        body=json.dumps(body),
+        status_code=status_code,
+        mimetype="application/json",
+        headers=headers,
+    )
+
+
+async def problem_exception_handler(request, exc: ProblemException):
+    body = {
+        "type": exc.type or "about:blank",
+        "title": exc.title,
+        "detail": exc.detail,
+        "status": exc.status,
+    }
+    if exc.instance is not None:
+        body["instance"] = exc.instance
+    if exc.ext:
+        body.update(exc.ext)
+    return _json_response(body, exc.status, headers=exc.headers)
+
+
+async def http_exception_handler(request, exc: StarletteHTTPException):
+    body = {
+        "type": "about:blank",
+        "title": exc.detail if exc.status_code < 500 else "Internal Server Error",
+        "detail": exc.detail,
+        "status": exc.status_code,
+    }
+    return _json_response(body, exc.status_code, headers=exc.headers)
+
+
+async def general_exception_handler(request, exc):
+    if isinstance(exc, anyio.EndOfStream):
+        raise
+
+    logger.exception(
+        "Unhandled exception in request: %s %s",
+        getattr(request, "method", None),
+        getattr(request, "url", None),
+    )
+    return _json_response(
+        {
+            "type": "about:blank",
+            "title": "Internal Server Error",
+            "detail": "The server encountered an internal error.",
+            "status": 500,
+        },
+        500,
+    )

--- a/compose/backend/neurosynth_compose/tests/test_asgi_error_surface.py
+++ b/compose/backend/neurosynth_compose/tests/test_asgi_error_surface.py
@@ -1,0 +1,120 @@
+import pytest
+from flask import abort
+from jose.jwt import encode
+from starlette.testclient import TestClient
+from werkzeug.routing import Rule
+
+
+def _assert_json_error_with_cors(response, origin=None):
+    assert response.headers["content-type"].startswith("application/json")
+    assert "application/problem+json" not in response.headers["content-type"]
+    if origin is not None:
+        assert response.headers["Access-Control-Allow-Origin"] == origin
+        assert response.headers["Access-Control-Allow-Credentials"] == "true"
+        assert response.headers["Vary"] == "Origin"
+
+
+def _install_asgi_error_test_routes(app):
+    if "__asgi_error_abort" not in app.view_functions:
+
+        def _abort_status(status_code):
+            abort(status_code, description=f"test abort {status_code}")
+
+        app.url_map.add(
+            Rule(
+                "/__test/asgi-errors/abort/<int:status_code>",
+                endpoint="__asgi_error_abort",
+                methods=["GET"],
+            )
+        )
+        app.view_functions["__asgi_error_abort"] = _abort_status
+
+    if "__asgi_error_runtime" not in app.view_functions:
+
+        def _raise_runtime_error():
+            raise RuntimeError("asgi runtime failure")
+
+        app.url_map.add(
+            Rule(
+                "/__test/asgi-errors/runtime",
+                endpoint="__asgi_error_runtime",
+                methods=["GET"],
+            )
+        )
+        app.view_functions["__asgi_error_runtime"] = _raise_runtime_error
+
+
+@pytest.fixture(scope="module")
+def asgi_error_client(app):
+    _install_asgi_error_test_routes(app)
+    client = TestClient(app.extensions["connexion_asgi"], raise_server_exceptions=False)
+    try:
+        yield client
+    finally:
+        client.close()
+
+
+def test_connexion_parameter_validation_error_is_handled_by_asgi(asgi_error_client):
+    response = asgi_error_client.get("/api/meta-analyses?page_size=not-an-int")
+
+    assert response.status_code == 400
+    _assert_json_error_with_cors(response)
+    body = response.json()
+    assert body["status"] == 400
+    assert body["title"] == "Bad Request"
+
+
+def test_connexion_body_validation_error_is_handled_by_asgi(
+    asgi_error_client, mock_add_users
+):
+    token = encode({"sub": "user1-id"}, "abc", algorithm="HS256")
+
+    response = asgi_error_client.post(
+        "/api/meta-analyses",
+        json={"name": 123},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 400
+    _assert_json_error_with_cors(response)
+    body = response.json()
+    assert body["status"] == 400
+    assert body["title"] == "Bad Request"
+
+
+@pytest.mark.parametrize("status_code", [401, 404, 422])
+def test_flask_abort_errors_are_handled_by_asgi(asgi_error_client, status_code):
+    response = asgi_error_client.get(
+        f"/__test/asgi-errors/abort/{status_code}",
+        headers={"Origin": "https://client.example"},
+    )
+
+    assert response.status_code == status_code
+    _assert_json_error_with_cors(response, "https://client.example")
+    body = response.json()
+    assert body["status"] == status_code
+    assert body["detail"] == f"test abort {status_code}"
+
+
+def test_generic_api_error_is_handled_by_asgi(asgi_error_client):
+    response = asgi_error_client.get("/__test/asgi-errors/runtime")
+
+    assert response.status_code == 500
+    _assert_json_error_with_cors(response)
+    body = response.json()
+    assert body["status"] == 500
+    assert body["title"] == "Internal Server Error"
+
+
+def test_admin_auth_failure_remains_flask_owned_with_cors(asgi_error_client):
+    response = asgi_error_client.get(
+        "/admin/",
+        headers={"Origin": "https://client.example"},
+    )
+
+    assert response.status_code == 401
+    assert response.text == "Authentication required"
+    assert response.headers["WWW-Authenticate"] == 'Basic realm="Admin"'
+    assert response.headers["Access-Control-Allow-Origin"] == "https://client.example"
+    assert response.headers["Access-Control-Allow-Credentials"] == "true"
+    assert response.headers["Vary"] == "Origin"

--- a/store/backend/neurostore/__init__.py
+++ b/store/backend/neurostore/__init__.py
@@ -1,4 +1,3 @@
-import json
 import os
 from copy import deepcopy
 from pathlib import Path
@@ -7,6 +6,7 @@ import connexion
 import flask
 from authlib.integrations.flask_client import OAuth
 from connexion.exceptions import OAuthProblem
+from connexion.exceptions import ProblemException
 from connexion.jsonifier import Jsonifier
 from connexion.resolver import MethodResolver
 from connexion.validators import VALIDATOR_MAP
@@ -16,16 +16,17 @@ from flask_admin import Admin, AdminIndexView
 from flask_admin.contrib.sqla import ModelView
 from flask_admin.theme import Bootstrap4Theme
 from flask_orjson import OrjsonProvider
+from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.middleware.cors import CORSMiddleware
 
 from neurostore.config import resolve_config_object
 from neurostore.database import init_db
 from neurostore.exceptions.base import NeuroStoreException
 from neurostore.exceptions.handlers import (
-    flask_general_body_and_status,
-    flask_neurostore_body_and_status,
     general_exception_handler,
+    http_exception_handler,
     neurostore_exception_handler,
+    problem_exception_handler,
 )
 from neurostore.extensions import cache
 from neurostore.resources import iter_request_body_validation_skip_rules
@@ -235,36 +236,11 @@ def create_app():
         allow_methods=["*"],
         allow_headers=["*"],
     )
-    connexion_app.exception_handlers = {
-        NeuroStoreException: neurostore_exception_handler,
-        OAuthProblem: asgi_oauth_problem_handler,
-        Exception: general_exception_handler,
-    }
-
-    def _flask_neurostore_handler(exc):
-        body, status = flask_neurostore_body_and_status(exc)
-        resp = app.response_class(
-            json.dumps(body), status=status, mimetype="application/json"
-        )
-        resp.headers["Access-Control-Allow-Origin"] = "*"
-        resp.headers["Access-Control-Allow-Methods"] = "*"
-        resp.headers["Access-Control-Allow-Headers"] = "*"
-        resp.headers["Access-Control-Allow-Credentials"] = "true"
-        return resp
-
-    def _flask_general_handler(exc):
-        body, status = flask_general_body_and_status(exc)
-        resp = app.response_class(
-            json.dumps(body), status=status, mimetype="application/json"
-        )
-        resp.headers["Access-Control-Allow-Origin"] = "*"
-        resp.headers["Access-Control-Allow-Methods"] = "*"
-        resp.headers["Access-Control-Allow-Headers"] = "*"
-        resp.headers["Access-Control-Allow-Credentials"] = "true"
-        return resp
-
-    app.register_error_handler(NeuroStoreException, _flask_neurostore_handler)
-    app.register_error_handler(Exception, _flask_general_handler)
+    connexion_app.add_error_handler(NeuroStoreException, neurostore_exception_handler)
+    connexion_app.add_error_handler(OAuthProblem, asgi_oauth_problem_handler)
+    connexion_app.add_error_handler(ProblemException, problem_exception_handler)
+    connexion_app.add_error_handler(StarletteHTTPException, http_exception_handler)
+    connexion_app.add_error_handler(Exception, general_exception_handler)
 
     os.environ["BEARERINFO_FUNC"] = app.config["BEARERINFO_FUNC"]
 

--- a/store/backend/neurostore/exceptions/handlers.py
+++ b/store/backend/neurostore/exceptions/handlers.py
@@ -1,15 +1,28 @@
+import json
 import logging
 import traceback
-from typing import Any, Dict, Tuple
 
 import anyio
+from connexion.exceptions import ProblemException
+from connexion.lifecycle import ConnexionResponse
+from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.requests import Request
-from starlette.responses import JSONResponse
 
 from neurostore.exceptions.base import InternalServerError, NeuroStoreException
 from neurostore.exceptions.utils.errors import ErrorDetail, ErrorResponse
 
 logger = logging.getLogger(__name__)
+
+
+def _json_response(
+    body: dict, status_code: int, headers: dict | None = None
+) -> ConnexionResponse:
+    return ConnexionResponse(
+        body=json.dumps(body),
+        status_code=status_code,
+        mimetype="application/json",
+        headers=headers,
+    )
 
 
 def _build_error_response_from_payload(
@@ -39,13 +52,31 @@ async def neurostore_exception_handler(request: Request, exc: NeuroStoreExceptio
     payload = exc.to_payload()
     err = _build_error_response_from_payload(payload, default_exc=exc)
     body = err.to_dict()
-    response = JSONResponse(body, status_code=err.status, media_type="application/json")
-    # Ensure CORS headers are present on ASGI error responses (mirrors WSGI handlers)
-    response.headers["Access-Control-Allow-Origin"] = "*"
-    response.headers["Access-Control-Allow-Methods"] = "*"
-    response.headers["Access-Control-Allow-Headers"] = "*"
-    response.headers["Access-Control-Allow-Credentials"] = "true"
-    return response
+    return _json_response(body, err.status)
+
+
+async def problem_exception_handler(request: Request, exc: ProblemException):
+    body = {
+        "type": exc.type or "about:blank",
+        "title": exc.title,
+        "detail": exc.detail,
+        "status": exc.status,
+    }
+    if exc.instance is not None:
+        body["instance"] = exc.instance
+    if exc.ext:
+        body.update(exc.ext)
+    return _json_response(body, exc.status, headers=exc.headers)
+
+
+async def http_exception_handler(request: Request, exc: StarletteHTTPException):
+    body = {
+        "type": "about:blank",
+        "title": exc.detail if exc.status_code < 500 else "Internal Server Error",
+        "detail": exc.detail,
+        "status": exc.status_code,
+    }
+    return _json_response(body, exc.status_code, headers=exc.headers)
 
 
 async def general_exception_handler(request: Request, exc: Exception):
@@ -70,34 +101,4 @@ async def general_exception_handler(request: Request, exc: Exception):
     )
     err = _build_error_response_from_payload(payload, default_exc=internal)
     body = err.to_dict()
-    response = JSONResponse(body, status_code=err.status, media_type="application/json")
-    # Ensure CORS headers are present on ASGI error responses (mirrors WSGI handlers)
-    response.headers["Access-Control-Allow-Origin"] = "*"
-    response.headers["Access-Control-Allow-Methods"] = "*"
-    response.headers["Access-Control-Allow-Headers"] = "*"
-    response.headers["Access-Control-Allow-Credentials"] = "true"
-    return response
-
-
-# Helper functions for WSGI/Flask handlers:
-# Return serializable body dict and status so core.py can construct a Flask Response
-def flask_neurostore_body_and_status(
-    exc: NeuroStoreException,
-) -> Tuple[Dict[str, Any], int]:
-    payload = exc.to_payload()
-    err = _build_error_response_from_payload(payload, default_exc=exc)
-    return err.to_dict(), err.status
-
-
-def flask_general_body_and_status(exc: Exception) -> Tuple[Dict[str, Any], int]:
-    if isinstance(exc, anyio.EndOfStream):
-        # Shouldn't normally occur in WSGI, but keep parity with ASGI behavior:
-        raise
-    logger.exception("Unhandled WSGI exception: %s", exc)
-    internal = InternalServerError()
-    payload = internal.to_payload()
-    payload["detail"] = (
-        str(exc) if logger.isEnabledFor(logging.DEBUG) else internal.detail
-    )
-    err = _build_error_response_from_payload(payload, default_exc=internal)
-    return err.to_dict(), err.status
+    return _json_response(body, err.status)

--- a/store/backend/neurostore/resources/auth.py
+++ b/store/backend/neurostore/resources/auth.py
@@ -3,9 +3,9 @@ from contextlib import contextmanager
 from urllib.request import urlopen
 
 from connexion.exceptions import OAuthProblem
+from connexion.lifecycle import ConnexionResponse
 from flask import current_app, has_app_context
 from jose import jwt
-from starlette.responses import JSONResponse
 from werkzeug.local import LocalProxy
 
 
@@ -13,29 +13,20 @@ def _oauth_problem(detail):
     return OAuthProblem(detail=detail)
 
 
-def _apply_cors_headers(response, origin=None):
-    response.headers["Access-Control-Allow-Origin"] = origin or "*"
-    response.headers["Access-Control-Allow-Methods"] = "*"
-    response.headers["Access-Control-Allow-Headers"] = "*"
-    response.headers["Access-Control-Allow-Credentials"] = "true"
-    if origin:
-        response.headers["Vary"] = "Origin"
-    return response
-
-
 async def asgi_oauth_problem_handler(request, exc):
     status_code = getattr(exc, "status_code", 401)
-    response = JSONResponse(
-        {
-            "type": "about:blank",
-            "title": "Unauthorized" if status_code == 401 else "Error",
-            "detail": getattr(exc, "detail", str(exc)),
-            "status": status_code,
-        },
+    return ConnexionResponse(
+        body=json.dumps(
+            {
+                "type": "about:blank",
+                "title": "Unauthorized" if status_code == 401 else "Error",
+                "detail": getattr(exc, "detail", str(exc)),
+                "status": status_code,
+            }
+        ),
         status_code=status_code,
-        media_type="application/problem+json",
+        mimetype="application/json",
     )
-    return _apply_cors_headers(response, request.headers.get("origin"))
 
 
 _flask_app = None

--- a/store/backend/neurostore/tests/api/test_base_studies.py
+++ b/store/backend/neurostore/tests/api/test_base_studies.py
@@ -2270,12 +2270,16 @@ def test_feature_flatten(auth_client, ingest_demographic_features):
 
 def test_invalid_search_query_cors(auth_client):
     """Test that invalid search query returns 400 with CORS headers"""
-    result = auth_client.get("/api/base-studies/?search=AND+OR")
+    origin = "https://client.example"
+    result = auth_client.get(
+        "/api/base-studies/?search=AND+OR",
+        headers={"Origin": origin},
+    )
     assert result.status_code == 400
     assert "Access-Control-Allow-Origin" in result.headers
-    assert "Access-Control-Allow-Methods" in result.headers
-    assert "Access-Control-Allow-Headers" in result.headers
-    assert result.headers["Access-Control-Allow-Origin"] == "*"
+    assert result.headers["Access-Control-Allow-Origin"] == origin
+    assert result.headers["Access-Control-Allow-Credentials"] == "true"
+    assert result.headers["Vary"] == "Origin"
 
 
 def test_base_studies_year_range(auth_client, session):

--- a/store/backend/neurostore/tests/test_asgi_error_surface.py
+++ b/store/backend/neurostore/tests/test_asgi_error_surface.py
@@ -1,0 +1,141 @@
+import pytest
+from flask import abort
+from starlette.testclient import TestClient
+from werkzeug.routing import Rule
+
+from neurostore.exceptions.factories import create_not_found_error
+
+
+def _assert_json_error_with_cors(response, origin=None):
+    assert response.headers["content-type"].startswith("application/json")
+    assert "application/problem+json" not in response.headers["content-type"]
+    if origin is not None:
+        assert response.headers["Access-Control-Allow-Origin"] == origin
+        assert response.headers["Access-Control-Allow-Credentials"] == "true"
+        assert response.headers["Vary"] == "Origin"
+
+
+def _install_asgi_error_test_routes(app):
+    if "__asgi_error_abort" not in app.view_functions:
+
+        def _abort_status(status_code):
+            abort(status_code, description=f"test abort {status_code}")
+
+        app.url_map.add(
+            Rule(
+                "/__test/asgi-errors/abort/<int:status_code>",
+                endpoint="__asgi_error_abort",
+                methods=["GET"],
+            )
+        )
+        app.view_functions["__asgi_error_abort"] = _abort_status
+
+    if "__asgi_error_domain" not in app.view_functions:
+
+        def _raise_domain_error():
+            raise create_not_found_error("Widget", "abc")
+
+        app.url_map.add(
+            Rule(
+                "/__test/asgi-errors/domain",
+                endpoint="__asgi_error_domain",
+                methods=["GET"],
+            )
+        )
+        app.view_functions["__asgi_error_domain"] = _raise_domain_error
+
+    if "__asgi_error_runtime" not in app.view_functions:
+
+        def _raise_runtime_error():
+            raise RuntimeError("asgi runtime failure")
+
+        app.url_map.add(
+            Rule(
+                "/__test/asgi-errors/runtime",
+                endpoint="__asgi_error_runtime",
+                methods=["GET"],
+            )
+        )
+        app.view_functions["__asgi_error_runtime"] = _raise_runtime_error
+
+
+@pytest.fixture(scope="module")
+def asgi_error_client(app):
+    _install_asgi_error_test_routes(app)
+    client = TestClient(app.extensions["connexion_asgi"], raise_server_exceptions=False)
+    try:
+        yield client
+    finally:
+        client.close()
+
+
+def test_connexion_validation_error_is_handled_by_asgi(asgi_error_client):
+    response = asgi_error_client.post("/api/pipeline-configs/", json=[])
+
+    assert response.status_code == 400
+    _assert_json_error_with_cors(response)
+    body = response.json()
+    assert body["status"] == 400
+    assert body["title"] == "Bad Request"
+
+
+def test_connexion_security_error_is_handled_by_asgi(asgi_error_client):
+    response = asgi_error_client.post(
+        "/api/pipelines/",
+        json={},
+        headers={"Origin": "https://client.example"},
+    )
+
+    assert response.status_code == 401
+    _assert_json_error_with_cors(response, "https://client.example")
+    body = response.json()
+    assert body["status"] == 401
+    assert body["title"] == "Unauthorized"
+
+
+@pytest.mark.parametrize("status_code", [401, 404, 422])
+def test_flask_abort_errors_are_handled_by_asgi(asgi_error_client, status_code):
+    response = asgi_error_client.get(
+        f"/__test/asgi-errors/abort/{status_code}",
+        headers={"Origin": "https://client.example"},
+    )
+
+    assert response.status_code == status_code
+    _assert_json_error_with_cors(response, "https://client.example")
+    body = response.json()
+    assert body["status"] == status_code
+    assert body["detail"] == f"test abort {status_code}"
+
+
+def test_neurostore_domain_error_is_handled_by_asgi(asgi_error_client):
+    response = asgi_error_client.get("/__test/asgi-errors/domain")
+
+    assert response.status_code == 404
+    _assert_json_error_with_cors(response)
+    body = response.json()
+    assert body["status"] == 404
+    assert body["title"] == "Not Found"
+
+
+def test_generic_api_error_is_handled_by_asgi(asgi_error_client):
+    response = asgi_error_client.get("/__test/asgi-errors/runtime")
+
+    assert response.status_code == 500
+    _assert_json_error_with_cors(response)
+    body = response.json()
+    assert body["status"] == 500
+    assert body["title"] == "Internal Server Error"
+
+
+def test_admin_auth_failure_remains_flask_owned_with_cors(asgi_error_client):
+    response = asgi_error_client.get(
+        "/admin/",
+        headers={"Origin": "https://client.example"},
+    )
+
+    assert response.status_code == 401
+    assert response.text == "Authentication required"
+    assert response.headers["WWW-Authenticate"] == 'Basic realm="Admin"'
+    assert response.headers["Access-Control-Allow-Origin"] == "https://client.example"
+    assert response.headers["Access-Control-Allow-Credentials"] == "true"
+    assert response.headers["Vary"] == "Origin"

--- a/store/backend/neurostore/tests/test_auth.py
+++ b/store/backend/neurostore/tests/test_auth.py
@@ -47,6 +47,8 @@ def test_studysets_no_auth_returns_cors_headers(app):
         client.close()
 
     assert response.status_code == 401
+    assert response.headers["content-type"].startswith("application/json")
+    assert "application/problem+json" not in response.headers["content-type"]
     assert response.headers.get("Access-Control-Allow-Origin") == origin
     assert response.headers.get("Access-Control-Allow-Credentials") == "true"
     assert response.headers.get("Vary") == "Origin"
@@ -66,6 +68,8 @@ def test_studysets_bad_token_returns_cors_headers(app):
         client.close()
 
     assert response.status_code == 401
+    assert response.headers["content-type"].startswith("application/json")
+    assert "application/problem+json" not in response.headers["content-type"]
     assert response.headers.get("Access-Control-Allow-Origin") == origin
     assert response.headers.get("Access-Control-Allow-Credentials") == "true"
     assert response.headers.get("Vary") == "Origin"

--- a/store/backend/neurostore/tests/test_error_handling.py
+++ b/store/backend/neurostore/tests/test_error_handling.py
@@ -127,7 +127,7 @@ def test_neurostore_exception_handler():
 
         response = await neurostore_exception_handler(request, exc)
         assert response.status_code == 404
-        assert response.media_type == "application/json"
+        assert response.mimetype == "application/json"
         body = json.loads(response.body)
         assert body["status"] == 404
         assert body["title"] == "Not Found"
@@ -144,7 +144,7 @@ def test_general_exception_handler():
 
         response = await general_exception_handler(request, exc)
         assert response.status_code == 500
-        assert response.media_type == "application/json"
+        assert response.mimetype == "application/json"
         body = json.loads(response.body)
         assert body["status"] == 500
         assert body["title"] == "Internal Server Error"


### PR DESCRIPTION
some errors are handled by flask and emitted by flask and others by starlette, making it difficult to tell which areas are handled. This also led to a bunch of CORS issues, since some error responses were not decorated properly, the current code does handle that by adding cors headers to flask requests, but this pull request aims to simplify and put more responsibility on asgi interface. Some responsibility is still on flask (like the /admin path) and there are many extensions that still rely on flask.

this is in preparation to write the API errors into logs so we can better track the weird one off/hard to replicate errors and better understand the context around them.