### PR TITLE
[ENH] add empty-state placeholder to projects page

### DIFF
--- a/compose/neurosynth-frontend/src/components/Buttons/CreateProjectButton.tsx
+++ b/compose/neurosynth-frontend/src/components/Buttons/CreateProjectButton.tsx
@@ -8,7 +8,6 @@ import { useCreateProject } from 'hooks';
 import { ProjectSearchCriteria, projectsSearchHelper } from 'hooks/projects/useGetProjects';
 import { generateNewProjectData, getNextUntitledProjectName } from 'pages/Project/store/ProjectStore.helpers';
 import { useState } from 'react';
-import { useQueryClient } from 'react-query';
 import { useNavigate } from 'react-router-dom';
 
 const projectSearchCriteria = new ProjectSearchCriteria(1, 1000);

--- a/compose/neurosynth-frontend/src/pages/Projects/ProjectsPage.tsx
+++ b/compose/neurosynth-frontend/src/pages/Projects/ProjectsPage.tsx
@@ -5,6 +5,7 @@ import StateHandlerComponent from 'components/StateHandlerComponent/StateHandler
 import { INeurosynthProjectReturn } from 'hooks/projects/useGetProjects';
 import useSearchProjects from 'pages/Projects/hooks/useSearchProjects';
 import ProjectsPageCard from './components/ProjectsPageCard';
+import ProjectsPageEmptyState from './components/ProjectsPageEmptyState';
 
 const ProjectsPage: React.FC = () => {
     const { user } = useAuth0();
@@ -53,9 +54,7 @@ const ProjectsPage: React.FC = () => {
                             </Box>
                         ))
                     ) : (
-                        <Typography sx={{ margin: '0 10px' }} color="warning.dark">
-                            No projects
-                        </Typography>
+                        <ProjectsPageEmptyState />
                     )}
                 </StateHandlerComponent>
             </SearchContainer>

--- a/compose/neurosynth-frontend/src/pages/Projects/components/ProjectsPageEmptyState.spec.tsx
+++ b/compose/neurosynth-frontend/src/pages/Projects/components/ProjectsPageEmptyState.spec.tsx
@@ -1,0 +1,29 @@
+import { vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ProjectsPageEmptyState from './ProjectsPageEmptyState';
+
+// Isolate the empty-state UI from the CTA's dependency tree (Auth0/react-query/router).
+vi.mock('components/Buttons/CreateProjectButton', () => ({
+    default: () => <button data-testid="create-project-button">NEW PROJECT</button>,
+}));
+
+describe('ProjectsPageEmptyState', () => {
+    it('should render', () => {
+        render(<ProjectsPageEmptyState />);
+    });
+
+    it('should show the empty-state heading', () => {
+        render(<ProjectsPageEmptyState />);
+        expect(screen.getByText('No projects yet')).toBeInTheDocument();
+    });
+
+    it('should show supporting guidance text', () => {
+        render(<ProjectsPageEmptyState />);
+        expect(screen.getByText(/create your first project/i)).toBeInTheDocument();
+    });
+
+    it('should render the create-project call-to-action', () => {
+        render(<ProjectsPageEmptyState />);
+        expect(screen.getByTestId('create-project-button')).toBeInTheDocument();
+    });
+});

--- a/compose/neurosynth-frontend/src/pages/Projects/components/ProjectsPageEmptyState.spec.tsx
+++ b/compose/neurosynth-frontend/src/pages/Projects/components/ProjectsPageEmptyState.spec.tsx
@@ -1,5 +1,6 @@
 import { vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import { MockThemeProvider } from 'testing/helpers';
 import ProjectsPageEmptyState from './ProjectsPageEmptyState';
 
 // Isolate the empty-state UI from the CTA's dependency tree (Auth0/react-query/router).
@@ -7,23 +8,32 @@ vi.mock('components/Buttons/CreateProjectButton', () => ({
     default: () => <button data-testid="create-project-button">NEW PROJECT</button>,
 }));
 
+// Render within the app theme so the component resolves palette tokens (e.g. muted.main)
+// the same way it does in production.
+const renderEmptyState = () =>
+    render(
+        <MockThemeProvider>
+            <ProjectsPageEmptyState />
+        </MockThemeProvider>
+    );
+
 describe('ProjectsPageEmptyState', () => {
     it('should render', () => {
-        render(<ProjectsPageEmptyState />);
+        renderEmptyState();
     });
 
     it('should show the empty-state heading', () => {
-        render(<ProjectsPageEmptyState />);
+        renderEmptyState();
         expect(screen.getByText('No projects yet')).toBeInTheDocument();
     });
 
     it('should show supporting guidance text', () => {
-        render(<ProjectsPageEmptyState />);
+        renderEmptyState();
         expect(screen.getByText(/create your first project/i)).toBeInTheDocument();
     });
 
     it('should render the create-project call-to-action', () => {
-        render(<ProjectsPageEmptyState />);
+        renderEmptyState();
         expect(screen.getByTestId('create-project-button')).toBeInTheDocument();
     });
 });

--- a/compose/neurosynth-frontend/src/pages/Projects/components/ProjectsPageEmptyState.tsx
+++ b/compose/neurosynth-frontend/src/pages/Projects/components/ProjectsPageEmptyState.tsx
@@ -1,28 +1,39 @@
 import FolderOpenIcon from '@mui/icons-material/FolderOpen';
-import { Box, Typography } from '@mui/material';
+import { Avatar, Box, Typography } from '@mui/material';
+import { alpha } from '@mui/material/styles';
 import CreateProjectButton from 'components/Buttons/CreateProjectButton';
-import ProjectComponentsStyles from 'pages/Project/components/Project.styles';
 
 const ProjectsPageEmptyState: React.FC = () => {
     return (
         <Box
-            sx={[
-                ProjectComponentsStyles.stepCard,
-                ProjectComponentsStyles.getStartedContainer,
-                {
-                    borderColor: 'muted.main',
-                    flexDirection: 'column',
-                    textAlign: 'center',
-                    padding: '2rem',
-                    gap: '1rem',
-                },
-            ]}
+            sx={{
+                display: 'flex',
+                alignItems: 'center',
+                flexDirection: 'column',
+                textAlign: 'center',
+                padding: '2rem',
+                gap: 2,
+            }}
         >
-            <FolderOpenIcon sx={{ fontSize: '3rem', color: 'muted.main' }} />
-            <Typography variant="h6">No projects yet</Typography>
-            <Typography sx={{ color: 'muted.main', maxWidth: '420px' }}>
-                Projects organize your curation and meta-analysis workflow. Create your first project to get started.
-            </Typography>
+            <Avatar
+                sx={{
+                    width: 64,
+                    height: 64,
+                    bgcolor: (theme) => alpha(theme.palette.primary.main, 0.12),
+                    color: 'primary.main',
+                }}
+            >
+                <FolderOpenIcon sx={{ fontSize: '2rem' }} />
+            </Avatar>
+            <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 1, maxWidth: '420px' }}>
+                <Typography variant="h5" sx={{ fontWeight: 600 }}>
+                    No projects yet
+                </Typography>
+                <Typography variant="body1" color="text.secondary">
+                    Create your first project to organize curation, coordinate extraction, and run meta-analyses in one
+                    place.
+                </Typography>
+            </Box>
             <CreateProjectButton />
         </Box>
     );

--- a/compose/neurosynth-frontend/src/pages/Projects/components/ProjectsPageEmptyState.tsx
+++ b/compose/neurosynth-frontend/src/pages/Projects/components/ProjectsPageEmptyState.tsx
@@ -1,0 +1,31 @@
+import FolderOpenIcon from '@mui/icons-material/FolderOpen';
+import { Box, Typography } from '@mui/material';
+import CreateProjectButton from 'components/Buttons/CreateProjectButton';
+import ProjectComponentsStyles from 'pages/Project/components/Project.styles';
+
+const ProjectsPageEmptyState: React.FC = () => {
+    return (
+        <Box
+            sx={[
+                ProjectComponentsStyles.stepCard,
+                ProjectComponentsStyles.getStartedContainer,
+                {
+                    borderColor: 'muted.main',
+                    flexDirection: 'column',
+                    textAlign: 'center',
+                    padding: '2rem',
+                    gap: '1rem',
+                },
+            ]}
+        >
+            <FolderOpenIcon sx={{ fontSize: '3rem', color: 'muted.main' }} />
+            <Typography variant="h6">No projects yet</Typography>
+            <Typography sx={{ color: 'muted.main', maxWidth: '420px' }}>
+                Projects organize your curation and meta-analysis workflow. Create your first project to get started.
+            </Typography>
+            <CreateProjectButton />
+        </Box>
+    );
+};
+
+export default ProjectsPageEmptyState;


### PR DESCRIPTION
When a user has no projects, the page showed only a bare "No projects" message. This replaces it with a friendly empty-state placeholder — folder icon, "No projects yet", a line of guidance, and a NEW PROJECT call-to-action — modeled on the curation phase's "get started" card. Reuses the existing `CreateProjectButton`, so no new project-creation logic. Frontend-only, with a colocated Vitest spec.

Closes #1598

**Before / After**

![before](https://raw.githubusercontent.com/lobennett/neurostore/evidence/1598-empty-state/before.png)
![after](https://raw.githubusercontent.com/lobennett/neurostore/evidence/1598-empty-state/after.png)