### PR TITLE
[FIX] allow typing decimal/leading-zero values in numeric meta-analysis params

### DIFF
--- a/compose/neurosynth-frontend/src/pages/MetaAnalysis/components/DynamicFormNumericInput.spec.tsx
+++ b/compose/neurosynth-frontend/src/pages/MetaAnalysis/components/DynamicFormNumericInput.spec.tsx
@@ -3,18 +3,17 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import DynamicFormNumericInput from './DynamicFormNumericInput';
 
+const baseParam = { type: 'float' as const, description: 'test-description', default: null };
+
 describe('DynamicFormNumericInput', () => {
     const mockOnUpdate = vi.fn();
+    beforeEach(() => mockOnUpdate.mockClear());
 
     it('should render', () => {
         render(
             <DynamicFormNumericInput
                 parameterName="null_iter"
-                parameter={{
-                    type: 'int',
-                    description: 'test-description',
-                    default: null,
-                }}
+                parameter={{ ...baseParam, type: 'int' }}
                 value={null}
                 onUpdate={mockOnUpdate}
             />
@@ -25,16 +24,11 @@ describe('DynamicFormNumericInput', () => {
         render(
             <DynamicFormNumericInput
                 parameterName="null_iter"
-                parameter={{
-                    type: 'float',
-                    description: 'test-description',
-                    default: null,
-                }}
+                parameter={baseParam}
                 value={0.12345}
                 onUpdate={mockOnUpdate}
             />
         );
-
         expect(screen.getByDisplayValue('0.12345')).toBeInTheDocument();
     });
 
@@ -42,11 +36,7 @@ describe('DynamicFormNumericInput', () => {
         render(
             <DynamicFormNumericInput
                 parameterName="null_iter"
-                parameter={{
-                    type: 'int',
-                    description: 'test-description',
-                    default: null,
-                }}
+                parameter={{ ...baseParam, type: 'int' }}
                 value={5}
                 onUpdate={mockOnUpdate}
             />
@@ -58,20 +48,69 @@ describe('DynamicFormNumericInput', () => {
         render(
             <DynamicFormNumericInput
                 parameterName="null_iter"
-                parameter={{
-                    type: 'int',
-                    description: 'test-description',
-                    default: null,
-                }}
+                parameter={{ ...baseParam, type: 'int' }}
                 value={5}
                 onUpdate={mockOnUpdate}
             />
         );
-        const input = screen.getByRole('spinbutton');
+        const input = screen.getByRole('textbox');
         userEvent.type(input, '3');
+        expect(mockOnUpdate).toHaveBeenCalledWith({ null_iter: 53 });
+    });
 
-        expect(mockOnUpdate).toHaveBeenCalledWith({
-            null_iter: 53,
-        });
+    it('should display 0 instead of clearing (leading-zero regression)', () => {
+        render(
+            <DynamicFormNumericInput
+                parameterName="voxel_thresh"
+                parameter={baseParam}
+                value={0}
+                onUpdate={mockOnUpdate}
+            />
+        );
+        expect(screen.getByDisplayValue('0')).toBeInTheDocument();
+    });
+
+    it('should let the user type a leading-zero decimal', () => {
+        render(
+            <DynamicFormNumericInput
+                parameterName="voxel_thresh"
+                parameter={baseParam}
+                value={null}
+                onUpdate={mockOnUpdate}
+            />
+        );
+        const input = screen.getByRole('textbox');
+        userEvent.type(input, '0.001');
+        expect(screen.getByDisplayValue('0.001')).toBeInTheDocument();
+        expect(mockOnUpdate).toHaveBeenLastCalledWith({ voxel_thresh: 0.001 });
+    });
+
+    it('should emit null when cleared', () => {
+        render(
+            <DynamicFormNumericInput
+                parameterName="voxel_thresh"
+                parameter={baseParam}
+                value={5}
+                onUpdate={mockOnUpdate}
+            />
+        );
+        const input = screen.getByRole('textbox');
+        userEvent.clear(input);
+        expect(mockOnUpdate).toHaveBeenLastCalledWith({ voxel_thresh: null });
+    });
+
+    it('should ignore non-numeric input', () => {
+        render(
+            <DynamicFormNumericInput
+                parameterName="voxel_thresh"
+                parameter={baseParam}
+                value={null}
+                onUpdate={mockOnUpdate}
+            />
+        );
+        const input = screen.getByRole('textbox');
+        userEvent.type(input, 'a');
+        expect(screen.getByRole('textbox')).toHaveValue('');
+        expect(mockOnUpdate).not.toHaveBeenCalled();
     });
 });

--- a/compose/neurosynth-frontend/src/pages/MetaAnalysis/components/DynamicFormNumericInput.spec.tsx
+++ b/compose/neurosynth-frontend/src/pages/MetaAnalysis/components/DynamicFormNumericInput.spec.tsx
@@ -85,6 +85,21 @@ describe('DynamicFormNumericInput', () => {
         expect(mockOnUpdate).toHaveBeenLastCalledWith({ voxel_thresh: 0.001 });
     });
 
+    it('should let the user type a leading decimal point and numbers', () => {
+        render(
+            <DynamicFormNumericInput
+                parameterName="voxel_thresh"
+                parameter={baseParam}
+                value={null}
+                onUpdate={mockOnUpdate}
+            />
+        );
+        const input = screen.getByRole('textbox');
+        userEvent.type(input, '.01');
+        expect(screen.getByDisplayValue('.01')).toBeInTheDocument();
+        expect(mockOnUpdate).toHaveBeenLastCalledWith({ voxel_thresh: 0.01 });
+    });
+
     it('should emit null when cleared', () => {
         render(
             <DynamicFormNumericInput

--- a/compose/neurosynth-frontend/src/pages/MetaAnalysis/components/DynamicFormNumericInput.tsx
+++ b/compose/neurosynth-frontend/src/pages/MetaAnalysis/components/DynamicFormNumericInput.tsx
@@ -2,8 +2,40 @@ import { Box, TextField } from '@mui/material';
 import { IDynamicFormInput } from 'pages/MetaAnalysis/components/DynamicForm.types';
 import MetaAnalysisDynamicFormTitle from './MetaAnalysisDynamicFormTitle';
 import DynamicFormStyles from 'pages/MetaAnalysis/components//DynamicFormStyles';
+import { useEffect, useState } from 'react';
+
+// Matches a number being typed in-progress: '', '0', '0.', '0.001', '-0.5'
+const NUMERIC_IN_PROGRESS = /^-?\d*\.?\d*$/;
+
+const toRaw = (value: any): string => (value === null || value === undefined ? '' : String(value));
 
 const DynamicFormNumericInput: React.FC<IDynamicFormInput> = (props) => {
+    const [rawValue, setRawValue] = useState<string>(toRaw(props.value));
+
+    // Sync external value changes, but don't clobber an in-progress entry like "0."
+    // (which parses to the same number we already emitted).
+    useEffect(() => {
+        const parsed = rawValue === '' ? null : parseFloat(rawValue);
+        if (props.value !== parsed) {
+            setRawValue(toRaw(props.value));
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [props.value]);
+
+    const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const text = event.target.value;
+        if (text !== '' && !NUMERIC_IN_PROGRESS.test(text)) return;
+        setRawValue(text);
+        if (text === '') {
+            props.onUpdate({ [props.parameterName]: null });
+            return;
+        }
+        const parsed = parseFloat(text);
+        if (!isNaN(parsed)) {
+            props.onUpdate({ [props.parameterName]: parsed });
+        }
+    };
+
     return (
         <Box sx={DynamicFormStyles.input}>
             <MetaAnalysisDynamicFormTitle
@@ -16,27 +48,12 @@ const DynamicFormNumericInput: React.FC<IDynamicFormInput> = (props) => {
                 <TextField
                     disabled={props.disabled}
                     name={props.parameterName}
-                    onWheel={(event) => {
-                        event.preventDefault();
-                    }}
-                    onChange={(event) => {
-                        const parsedValue = parseFloat(event.target.value);
-                        if (event.target.value === '') {
-                            props.onUpdate({
-                                [props.parameterName]: null,
-                            });
-                        } else if (isNaN(parsedValue)) {
-                            return;
-                        } else {
-                            props.onUpdate({
-                                [props.parameterName]: parsedValue,
-                            });
-                        }
-                    }}
-                    value={props.value || ''}
+                    onChange={handleChange}
+                    value={rawValue}
                     label="number"
                     sx={{ width: '100%', opacity: props.disabled ? 0.4 : 1 }}
-                    type="number"
+                    type="text"
+                    inputProps={{ inputMode: 'decimal' }}
                 />
             </Box>
         </Box>


### PR DESCRIPTION
The numeric param input rendered `value={props.value || ''}`, so a value of `0` is falsy and the field cleared itself the moment you typed a leading zero — you could never enter a small decimal like a `voxel_thresh` of `0.001` (it collapses to `1`). The per-keystroke `parseFloat` round-trip against a `type="number"` input also dropped in-progress decimals.

This makes the input a controlled string field (`type="text"` + `inputMode="decimal"`): it keeps the raw text the user typed and still emits a parsed number (or null) to the parent, so `0`, `0.`, and `0.001` all type cleanly.

Closes #1387

**Before** — typing `0.001` collapses to `1`:

![before](https://raw.githubusercontent.com/lobennett/neurostore/evidence/1387-voxel-thresh/before.gif)

**After** — typing `0.001` works:

![after](https://raw.githubusercontent.com/lobennett/neurostore/evidence/1387-voxel-thresh/after.gif)