### PR TITLE
[ENH] add copyable studyset/annotation IDs to extraction and overview

### DIFF
--- a/compose/neurosynth-frontend/src/components/CopyableId/CopyableId.spec.tsx
+++ b/compose/neurosynth-frontend/src/components/CopyableId/CopyableId.spec.tsx
@@ -1,0 +1,41 @@
+import { vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CopyableId from './CopyableId';
+
+const mockCopy = vi.hoisted(() => vi.fn());
+const hookState = vi.hoisted(() => ({ copied: false }));
+
+vi.mock('hooks/useCopyToClipboard', () => ({
+    default: () => ({ copied: hookState.copied, copyToClipboard: mockCopy }),
+}));
+
+describe('CopyableId', () => {
+    beforeEach(() => {
+        mockCopy.mockClear();
+        hookState.copied = false;
+    });
+
+    it('renders the label and id', () => {
+        render(<CopyableId label="Studyset ID" id="abc123" />);
+        expect(screen.getByText('Studyset ID:')).toBeInTheDocument();
+        expect(screen.getByText('abc123')).toBeInTheDocument();
+    });
+
+    it('renders nothing when id is empty', () => {
+        const { container } = render(<CopyableId label="Studyset ID" id={null} />);
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it('copies the id when the copy button is clicked', () => {
+        render(<CopyableId label="Studyset ID" id="abc123" />);
+        userEvent.click(screen.getByRole('button', { name: 'Copy Studyset ID' }));
+        expect(mockCopy).toHaveBeenCalledWith('abc123');
+    });
+
+    it('shows the copied state', () => {
+        hookState.copied = true;
+        render(<CopyableId label="Studyset ID" id="abc123" />);
+        expect(screen.getByTestId('CheckIcon')).toBeInTheDocument();
+    });
+});

--- a/compose/neurosynth-frontend/src/components/CopyableId/CopyableId.tsx
+++ b/compose/neurosynth-frontend/src/components/CopyableId/CopyableId.tsx
@@ -1,0 +1,28 @@
+import CheckIcon from '@mui/icons-material/Check';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import { Box, IconButton, Tooltip, Typography } from '@mui/material';
+import useCopyToClipboard from 'hooks/useCopyToClipboard';
+
+const CopyableId: React.FC<{ label: string; id: string | null | undefined }> = ({ label, id }) => {
+    const { copied, copyToClipboard } = useCopyToClipboard();
+
+    if (!id) return null;
+
+    return (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
+            <Typography variant="caption" sx={{ color: 'muted.main' }}>
+                {label}:
+            </Typography>
+            <Typography variant="caption" sx={{ fontFamily: 'monospace' }}>
+                {id}
+            </Typography>
+            <Tooltip title={copied ? 'Copied!' : `Copy ${label}`}>
+                <IconButton size="small" aria-label={`Copy ${label}`} onClick={() => copyToClipboard(id)}>
+                    {copied ? <CheckIcon fontSize="inherit" color="success" /> : <ContentCopyIcon fontSize="inherit" />}
+                </IconButton>
+            </Tooltip>
+        </Box>
+    );
+};
+
+export default CopyableId;

--- a/compose/neurosynth-frontend/src/components/CopyableId/CopyableId.tsx
+++ b/compose/neurosynth-frontend/src/components/CopyableId/CopyableId.tsx
@@ -1,6 +1,6 @@
 import CheckIcon from '@mui/icons-material/Check';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
-import { Box, IconButton, Tooltip, Typography } from '@mui/material';
+import { Box, Divider, IconButton, Tooltip, Typography } from '@mui/material';
 import useCopyToClipboard from 'hooks/useCopyToClipboard';
 
 const CopyableId: React.FC<{ label: string; id: string | null | undefined }> = ({ label, id }) => {
@@ -9,16 +9,53 @@ const CopyableId: React.FC<{ label: string; id: string | null | undefined }> = (
     if (!id) return null;
 
     return (
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
-            <Typography variant="caption" sx={{ color: 'muted.main' }}>
+        <Box
+            sx={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                border: '1px solid',
+                borderColor: 'divider',
+                borderRadius: '6px',
+                height: '24px',
+                fontSize: '0.65rem',
+            }}
+        >
+            <Typography
+                variant="caption"
+                sx={{
+                    color: 'muted.dark',
+                    px: 0.75,
+                    height: '100%',
+                    display: 'flex',
+                    alignItems: 'center',
+                    fontSize: 'inherit',
+                    lineHeight: 1,
+                    borderTopLeftRadius: '6px',
+                    borderBottomLeftRadius: '6px',
+                    bgcolor: 'grey.100',
+                }}
+            >
                 {label}:
             </Typography>
-            <Typography variant="caption" sx={{ fontFamily: 'monospace' }}>
+            <Divider orientation="vertical" flexItem />
+            <Typography
+                variant="caption"
+                sx={{ fontFamily: 'monospace', px: 0.75, fontSize: 'inherit', lineHeight: 1 }}
+            >
                 {id}
             </Typography>
             <Tooltip title={copied ? 'Copied!' : `Copy ${label}`}>
-                <IconButton size="small" aria-label={`Copy ${label}`} onClick={() => copyToClipboard(id)}>
-                    {copied ? <CheckIcon fontSize="inherit" color="success" /> : <ContentCopyIcon fontSize="inherit" />}
+                <IconButton
+                    size="small"
+                    aria-label={`Copy ${label}`}
+                    onClick={() => copyToClipboard(id)}
+                    sx={{ p: 0.25, mr: 0.25, fontSize: '0.75rem' }}
+                >
+                    {copied ? (
+                        <CheckIcon sx={{ fontSize: '16px' }} color="success" />
+                    ) : (
+                        <ContentCopyIcon sx={{ fontSize: '16px' }} />
+                    )}
                 </IconButton>
             </Tooltip>
         </Box>

--- a/compose/neurosynth-frontend/src/pages/Extraction/ExtractionPage.tsx
+++ b/compose/neurosynth-frontend/src/pages/Extraction/ExtractionPage.tsx
@@ -1,4 +1,5 @@
 import { Box, Button, Tooltip, Typography } from '@mui/material';
+import CopyableId from 'components/CopyableId/CopyableId';
 import LoadingStateIndicatorProject from 'components/LoadingStateIndicator/LoadingStateIndicatorProject';
 import NeurosynthBreadcrumbs from 'components/NeurosynthBreadcrumbs';
 import StateHandlerComponent from 'components/StateHandlerComponent/StateHandlerComponent';
@@ -13,6 +14,7 @@ import { IProjectPageLocationState } from 'pages/Project/ProjectPage';
 import {
     useGetProjectIsLoading,
     useProjectCurationColumns,
+    useProjectExtractionAnnotationId,
     useProjectExtractionStudysetId,
     useProjectName,
     useProjectUser,
@@ -33,6 +35,7 @@ const ExtractionPage: React.FC = () => {
 
     const projectName = useProjectName();
     const studysetId = useProjectExtractionStudysetId();
+    const annotationId = useProjectExtractionAnnotationId();
     const columns = useProjectCurationColumns();
     const loading = useGetProjectIsLoading();
     const extractionSummary = useGetExtractionSummary(projectId || '');
@@ -157,6 +160,10 @@ const ExtractionPage: React.FC = () => {
                             </span>
                         </Tooltip>
                     </Box>
+                </Box>
+                <Box sx={{ display: 'flex', gap: '1.5rem', marginBottom: '0.5rem' }}>
+                    <CopyableId label="Studyset ID" id={studysetId} />
+                    <CopyableId label="Annotation ID" id={annotationId} />
                 </Box>
                 {showReconcilePrompt && (
                     <Box sx={{ my: 1 }}>

--- a/compose/neurosynth-frontend/src/pages/Project/components/ProjectExtractionStep.tsx
+++ b/compose/neurosynth-frontend/src/pages/Project/components/ProjectExtractionStep.tsx
@@ -1,6 +1,8 @@
 import { Box, Button, Step, StepContent, StepLabel, StepProps, Typography } from '@mui/material';
+import CopyableId from 'components/CopyableId/CopyableId';
 import MoveToExtractionDialog from 'pages/Project/components/MoveToExtractionDialog';
 import { IProjectPageLocationState } from 'pages/Project/ProjectPage';
+import { useProjectExtractionAnnotationId, useProjectExtractionStudysetId } from 'pages/Project/store/ProjectStore';
 import { useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import ProjectExtractionStepCard from './ProjectExtractionStepCard';
@@ -14,6 +16,9 @@ interface IExtractionStep {
 const ProjectExtractionStep: React.FC<IExtractionStep & StepProps> = (props) => {
     const { extractionStepHasBeenInitialized, disabled, ...stepProps } = props;
     const location = useLocation();
+
+    const studysetId = useProjectExtractionStudysetId();
+    const annotationId = useProjectExtractionAnnotationId();
 
     const [moveToExtractionDialogIsOpen, setMoveToExtractionDialogIsOpen] = useState(
         !extractionStepHasBeenInitialized &&
@@ -44,6 +49,10 @@ const ProjectExtractionStep: React.FC<IExtractionStep & StepProps> = (props) => 
                         metadata) as well as analysis annotations that will be used to help filter analyses within your
                         studies
                     </Typography>
+                    <Box sx={{ display: 'flex', gap: '1.5rem', marginTop: '0.5rem' }}>
+                        <CopyableId label="Studyset ID" id={studysetId} />
+                        <CopyableId label="Annotation ID" id={annotationId} />
+                    </Box>
                     <Box sx={{ marginTop: '1rem' }}>
                         {extractionStepHasBeenInitialized ? (
                             <ProjectExtractionStepCard disabled={disabled} />


### PR DESCRIPTION
Surfaces the studyset-id and annotation-id with a one-click copy button on the Extraction stage and the project Overview, so they can be pasted into NiMARE to download the studyset/annotation directly (per the issue's use case). Adds a small reusable `CopyableId` component built on the existing `useCopyToClipboard` hook; no store or API changes.

Closes #1559

Verified live on a full local stack (a project taken through curation → extraction):

![extraction page](https://raw.githubusercontent.com/lobennett/neurostore/evidence/1559-copyable-ids/extraction-page.png)

Copy interaction:

![demo](https://raw.githubusercontent.com/lobennett/neurostore/evidence/1559-copyable-ids/copyable-demo.gif)