### PR TITLE
[ENH] resolve legacy /meta-analyses/:id URLs to the canonical project URL

### DIFF
--- a/compose/neurosynth-frontend/src/pages/BaseNavigation/BaseNavigation.tsx
+++ b/compose/neurosynth-frontend/src/pages/BaseNavigation/BaseNavigation.tsx
@@ -7,6 +7,7 @@ import CurationSearchPage from 'pages/CurationImport/CurationSearchPage';
 import ExtractionPage from 'pages/Extraction/ExtractionPage';
 import ForbiddenPage from 'pages/Forbidden/Forbidden';
 import HelpPage from 'pages/HelpPage/HelpPage';
+import MetaAnalysisRedirect from 'pages/MetaAnalysis/MetaAnalysisRedirect';
 import NotFoundPage from 'pages/NotFound/NotFoundPage';
 import ProjectEditMetaAnalyses from 'pages/Project/components/ProjectEditMetaAnalyses';
 import ProjectViewMetaAnalyses from 'pages/Project/components/ProjectViewMetaAnalyses';
@@ -226,6 +227,7 @@ const BaseNavigation: React.FC = () => {
                             </Box>
                         }
                     />
+                    <Route path="/meta-analyses/:metaAnalysisId" element={<MetaAnalysisRedirect />} />
                     <Route
                         path="*"
                         element={

--- a/compose/neurosynth-frontend/src/pages/MetaAnalysis/MetaAnalysisRedirect.spec.tsx
+++ b/compose/neurosynth-frontend/src/pages/MetaAnalysis/MetaAnalysisRedirect.spec.tsx
@@ -1,0 +1,49 @@
+import { vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import MetaAnalysisRedirect from './MetaAnalysisRedirect';
+
+const mockUseGet = vi.hoisted(() => vi.fn());
+
+vi.mock('hooks/metaAnalyses/useGetMetaAnalysisById', () => ({ default: mockUseGet }));
+vi.mock('react-router-dom', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('react-router-dom')>()),
+    useParams: () => ({ metaAnalysisId: '33sGF2kiiag6' }),
+    Navigate: ({ to }: { to: string }) => <div data-testid="navigate">{to}</div>,
+}));
+vi.mock('pages/NotFound/NotFoundPage', () => ({
+    default: () => <div data-testid="notfound">Not found</div>,
+}));
+vi.mock('components/NeurosynthLoader/NeurosynthLoader', () => ({
+    default: () => <div data-testid="loader" />,
+}));
+
+describe('MetaAnalysisRedirect', () => {
+    beforeEach(() => mockUseGet.mockReset());
+
+    it('redirects to the canonical project URL when resolved', () => {
+        mockUseGet.mockReturnValue({ data: { project: 'wuUuxSXTbw7Z' }, isLoading: false, isError: false });
+        render(<MetaAnalysisRedirect />);
+        expect(screen.getByTestId('navigate')).toHaveTextContent('/projects/wuUuxSXTbw7Z/meta-analyses/33sGF2kiiag6');
+    });
+
+    it('shows NotFound on error', () => {
+        mockUseGet.mockReturnValue({ data: undefined, isLoading: false, isError: true });
+        render(<MetaAnalysisRedirect />);
+        expect(screen.getByTestId('notfound')).toBeInTheDocument();
+        expect(screen.queryByTestId('navigate')).not.toBeInTheDocument();
+    });
+
+    it('shows NotFound when the meta-analysis has no project', () => {
+        mockUseGet.mockReturnValue({ data: { project: null }, isLoading: false, isError: false });
+        render(<MetaAnalysisRedirect />);
+        expect(screen.getByTestId('notfound')).toBeInTheDocument();
+        expect(screen.queryByTestId('navigate')).not.toBeInTheDocument();
+    });
+
+    it('shows a loader while loading', () => {
+        mockUseGet.mockReturnValue({ data: undefined, isLoading: true, isError: false });
+        render(<MetaAnalysisRedirect />);
+        expect(screen.getByTestId('loader')).toBeInTheDocument();
+        expect(screen.queryByTestId('navigate')).not.toBeInTheDocument();
+    });
+});

--- a/compose/neurosynth-frontend/src/pages/MetaAnalysis/MetaAnalysisRedirect.spec.tsx
+++ b/compose/neurosynth-frontend/src/pages/MetaAnalysis/MetaAnalysisRedirect.spec.tsx
@@ -1,15 +1,12 @@
-import { vi } from 'vitest';
+import { Mock, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import { useParams } from 'react-router-dom';
 import MetaAnalysisRedirect from './MetaAnalysisRedirect';
 
 const mockUseGet = vi.hoisted(() => vi.fn());
 
 vi.mock('hooks/metaAnalyses/useGetMetaAnalysisById', () => ({ default: mockUseGet }));
-vi.mock('react-router-dom', async (importOriginal) => ({
-    ...(await importOriginal<typeof import('react-router-dom')>()),
-    useParams: () => ({ metaAnalysisId: '33sGF2kiiag6' }),
-    Navigate: ({ to }: { to: string }) => <div data-testid="navigate">{to}</div>,
-}));
+vi.mock('react-router-dom');
 vi.mock('pages/NotFound/NotFoundPage', () => ({
     default: () => <div data-testid="notfound">Not found</div>,
 }));
@@ -18,32 +15,35 @@ vi.mock('components/NeurosynthLoader/NeurosynthLoader', () => ({
 }));
 
 describe('MetaAnalysisRedirect', () => {
-    beforeEach(() => mockUseGet.mockReset());
+    beforeEach(() => {
+        mockUseGet.mockReset();
+        (useParams as Mock).mockReturnValue({ metaAnalysisId: '33sGF2kiiag6' });
+    });
 
     it('redirects to the canonical project URL when resolved', () => {
         mockUseGet.mockReturnValue({ data: { project: 'wuUuxSXTbw7Z' }, isLoading: false, isError: false });
         render(<MetaAnalysisRedirect />);
-        expect(screen.getByTestId('navigate')).toHaveTextContent('/projects/wuUuxSXTbw7Z/meta-analyses/33sGF2kiiag6');
+        expect(screen.getByTestId('to')).toHaveTextContent('/projects/wuUuxSXTbw7Z/meta-analyses/33sGF2kiiag6');
     });
 
     it('shows NotFound on error', () => {
         mockUseGet.mockReturnValue({ data: undefined, isLoading: false, isError: true });
         render(<MetaAnalysisRedirect />);
         expect(screen.getByTestId('notfound')).toBeInTheDocument();
-        expect(screen.queryByTestId('navigate')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('to')).not.toBeInTheDocument();
     });
 
     it('shows NotFound when the meta-analysis has no project', () => {
         mockUseGet.mockReturnValue({ data: { project: null }, isLoading: false, isError: false });
         render(<MetaAnalysisRedirect />);
         expect(screen.getByTestId('notfound')).toBeInTheDocument();
-        expect(screen.queryByTestId('navigate')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('to')).not.toBeInTheDocument();
     });
 
     it('shows a loader while loading', () => {
         mockUseGet.mockReturnValue({ data: undefined, isLoading: true, isError: false });
         render(<MetaAnalysisRedirect />);
         expect(screen.getByTestId('loader')).toBeInTheDocument();
-        expect(screen.queryByTestId('navigate')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('to')).not.toBeInTheDocument();
     });
 });

--- a/compose/neurosynth-frontend/src/pages/MetaAnalysis/MetaAnalysisRedirect.spec.tsx
+++ b/compose/neurosynth-frontend/src/pages/MetaAnalysis/MetaAnalysisRedirect.spec.tsx
@@ -10,9 +10,7 @@ vi.mock('react-router-dom');
 vi.mock('pages/NotFound/NotFoundPage', () => ({
     default: () => <div data-testid="notfound">Not found</div>,
 }));
-vi.mock('components/NeurosynthLoader/NeurosynthLoader', () => ({
-    default: () => <div data-testid="loader" />,
-}));
+vi.mock('components/NeurosynthLoader/NeurosynthLoader');
 
 describe('MetaAnalysisRedirect', () => {
     beforeEach(() => {
@@ -43,7 +41,7 @@ describe('MetaAnalysisRedirect', () => {
     it('shows a loader while loading', () => {
         mockUseGet.mockReturnValue({ data: undefined, isLoading: true, isError: false });
         render(<MetaAnalysisRedirect />);
-        expect(screen.getByTestId('loader')).toBeInTheDocument();
+        expect(screen.getByTestId('neurosynth-loader')).toBeInTheDocument();
         expect(screen.queryByTestId('to')).not.toBeInTheDocument();
     });
 });

--- a/compose/neurosynth-frontend/src/pages/MetaAnalysis/MetaAnalysisRedirect.tsx
+++ b/compose/neurosynth-frontend/src/pages/MetaAnalysis/MetaAnalysisRedirect.tsx
@@ -1,0 +1,20 @@
+import { Navigate, useParams } from 'react-router-dom';
+import NeurosynthLoader from 'components/NeurosynthLoader/NeurosynthLoader';
+import NotFoundPage from 'pages/NotFound/NotFoundPage';
+import useGetMetaAnalysisById from 'hooks/metaAnalyses/useGetMetaAnalysisById';
+
+// Resolves a legacy, project-less /meta-analyses/:id URL (written into NeuroVault by
+// compose-runner) to the canonical project-scoped page.
+const MetaAnalysisRedirect: React.FC = () => {
+    const { metaAnalysisId } = useParams<{ metaAnalysisId: string }>();
+    const { data, isLoading, isError } = useGetMetaAnalysisById(metaAnalysisId);
+
+    if (isLoading) return <NeurosynthLoader loaded={false} />;
+
+    const projectId = data?.project;
+    if (isError || !projectId) return <NotFoundPage />;
+
+    return <Navigate replace to={`/projects/${projectId}/meta-analyses/${metaAnalysisId}`} />;
+};
+
+export default MetaAnalysisRedirect;


### PR DESCRIPTION
Project-less meta-analysis URLs (`/meta-analyses/:id`) — the links compose-runner writes into NeuroVault — currently 404, since every meta-analysis route is nested under a project. This adds an unprotected `/meta-analyses/:metaAnalysisId` route that looks up the meta-analysis, reads its `project`, and redirects (`replace`) to the canonical `/projects/:project/meta-analyses/:metaAnalysisId`; an unknown id still shows Not Found. Access control stays at the destination.

Closes #1564

_(Issue is `discussion`-labeled — went with the redirect; noted the project-less standalone-view alternative on the issue.)_

Verified live against a real meta-analysis (`33sGF2kiiag6` → project `wuUuxSXTbw7Z`):

**Before** — `/meta-analyses/33sGF2kiiag6` 404s:

![before](https://raw.githubusercontent.com/lobennett/neurostore/evidence/1564-legacy-url/before.png)

**After** — redirects to the canonical page:

![after](https://raw.githubusercontent.com/lobennett/neurostore/evidence/1564-legacy-url/after.png)