### PR TITLE
[ENH] search/filter the excluded studies list

### DIFF
--- a/compose/neurosynth-frontend/src/hooks/useMeasure.tsx
+++ b/compose/neurosynth-frontend/src/hooks/useMeasure.tsx
@@ -15,8 +15,12 @@ const useMeasure = <T extends HTMLElement>(): UseMeasureResult<T> => {
         if (!element) return;
 
         const resizeObserver = new ResizeObserver((entries) => {
-            if (!entries[0]) return;
-            const { width, height } = entries[0].contentRect;
+            const entry = entries[0];
+            if (!entry) return;
+            const borderBox = entry.borderBoxSize[0];
+            if (!borderBox) return;
+            const width = borderBox.inlineSize;
+            const height = borderBox.blockSize;
             setDimensions({ width, height });
         });
 

--- a/compose/neurosynth-frontend/src/pages/Curation/components/CurationBoardAIInterfaceExclude.helpers.spec.ts
+++ b/compose/neurosynth-frontend/src/pages/Curation/components/CurationBoardAIInterfaceExclude.helpers.spec.ts
@@ -1,0 +1,56 @@
+import { filterStubsBySearch } from './CurationBoardAIInterfaceExclude.helpers';
+import { ICurationStubStudy } from '../Curation.types';
+
+const makeStub = (over: Partial<ICurationStubStudy>): ICurationStubStudy => ({
+    id: 'id',
+    title: '',
+    authors: '',
+    keywords: '',
+    pmid: '',
+    pmcid: '',
+    doi: '',
+    articleYear: undefined,
+    journal: '',
+    abstractText: '',
+    articleLink: '',
+    exclusionTag: null,
+    identificationSource: { id: 'src', label: 'src' } as ICurationStubStudy['identificationSource'],
+    tags: [],
+    ...over,
+});
+
+const stubs = [
+    makeStub({ id: '1', title: 'Sleep and memory', authors: 'Smith J' }),
+    makeStub({ id: '2', title: 'Pain perception', authors: 'Wager T', journal: 'Science', articleYear: '2004' }),
+    makeStub({ id: '3', title: 'Fear conditioning', keywords: 'amygdala', pmid: '12345', doi: '10.1/x' }),
+];
+const ids = (result: ICurationStubStudy[]) => result.map((s) => s.id);
+
+describe('filterStubsBySearch', () => {
+    it('returns all stubs for an empty or whitespace term', () => {
+        expect(filterStubsBySearch(stubs, '')).toHaveLength(3);
+        expect(filterStubsBySearch(stubs, '   ')).toHaveLength(3);
+    });
+    it('matches title case-insensitively', () => {
+        expect(ids(filterStubsBySearch(stubs, 'SLEEP'))).toEqual(['1']);
+    });
+    it('matches authors', () => {
+        expect(ids(filterStubsBySearch(stubs, 'wager'))).toEqual(['2']);
+    });
+    it('matches journal', () => {
+        expect(ids(filterStubsBySearch(stubs, 'science'))).toEqual(['2']);
+    });
+    it('matches articleYear', () => {
+        expect(ids(filterStubsBySearch(stubs, '2004'))).toEqual(['2']);
+    });
+    it('matches keywords', () => {
+        expect(ids(filterStubsBySearch(stubs, 'amygdala'))).toEqual(['3']);
+    });
+    it('matches pmid and doi', () => {
+        expect(ids(filterStubsBySearch(stubs, '12345'))).toEqual(['3']);
+        expect(ids(filterStubsBySearch(stubs, '10.1/x'))).toEqual(['3']);
+    });
+    it('returns [] when nothing matches', () => {
+        expect(filterStubsBySearch(stubs, 'zzzznomatch')).toEqual([]);
+    });
+});

--- a/compose/neurosynth-frontend/src/pages/Curation/components/CurationBoardAIInterfaceExclude.helpers.ts
+++ b/compose/neurosynth-frontend/src/pages/Curation/components/CurationBoardAIInterfaceExclude.helpers.ts
@@ -1,0 +1,18 @@
+import { ICurationStubStudy } from '../Curation.types';
+
+/**
+ * Filter excluded-study stubs by a case-insensitive substring match against the
+ * bibliographic fields (title, authors, journal, year, keywords) and identifiers
+ * (pmid, doi). An empty/whitespace term returns all stubs unchanged.
+ */
+export const filterStubsBySearch = (stubs: ICurationStubStudy[], searchTerm: string): ICurationStubStudy[] => {
+    const term = searchTerm.trim().toLocaleLowerCase();
+    if (!term) return stubs;
+    return stubs.filter((stub) => {
+        const haystack = [stub.title, stub.authors, stub.journal, stub.articleYear, stub.keywords, stub.pmid, stub.doi]
+            .filter(Boolean)
+            .join(' ')
+            .toLocaleLowerCase();
+        return haystack.includes(term);
+    });
+};

--- a/compose/neurosynth-frontend/src/pages/Curation/components/CurationBoardAIInterfaceExclude.tsx
+++ b/compose/neurosynth-frontend/src/pages/Curation/components/CurationBoardAIInterfaceExclude.tsx
@@ -75,7 +75,8 @@ const CurationBoardAIInterfaceExclude: React.FC<{
     );
 
     const { ref: labelContainerRef, height: labelContainerHeight } = useMeasure<HTMLDivElement>();
-    const pxInVh = Math.round(windowHeight - 220 - labelContainerHeight);
+    const { ref: searchbarContainerRef, height: searchbarContainerHeight } = useMeasure<HTMLDivElement>();
+    const pxInVh = Math.round(windowHeight - 220 - labelContainerHeight - searchbarContainerHeight);
 
     // when the group changes, clear the search and select the first stub
     useEffect(() => {
@@ -133,11 +134,12 @@ const CurationBoardAIInterfaceExclude: React.FC<{
             ) : (
                 <Box>
                     <TextField
+                        ref={searchbarContainerRef}
                         size="small"
                         value={searchTerm}
                         onChange={(event) => setSearchTerm(event.target.value)}
                         placeholder="Search excluded studies..."
-                        sx={{ width: '260px', marginBottom: '0.5rem' }}
+                        sx={{ width: '260px', paddingBottom: '0.5rem' }}
                         InputProps={{
                             startAdornment: (
                                 <InputAdornment position="start">

--- a/compose/neurosynth-frontend/src/pages/Curation/components/CurationBoardAIInterfaceExclude.tsx
+++ b/compose/neurosynth-frontend/src/pages/Curation/components/CurationBoardAIInterfaceExclude.tsx
@@ -1,4 +1,5 @@
-import { Box, Typography } from '@mui/material';
+import { Box, InputAdornment, TextField, Typography } from '@mui/material';
+import SearchIcon from '@mui/icons-material/Search';
 import { useGetWindowHeight, useMeasure, useUserCanEdit } from 'hooks';
 import {
     useProjectCurationColumns,
@@ -14,6 +15,7 @@ import CurationEditableStubSummary from './CurationEditableStubSummary';
 import CurationStubListItemVirtualizedContainer from './CurationStubListItemVirtualizedContainer';
 import TextEdit from 'components/TextEdit/TextEdit';
 import { ENeurosynthTagIds } from 'pages/Project/store/ProjectStore.consts';
+import { filterStubsBySearch } from './CurationBoardAIInterfaceExclude.helpers';
 
 const CurationBoardAIInterfaceExclude: React.FC<{
     group: IGroupListItem;
@@ -22,6 +24,7 @@ const CurationBoardAIInterfaceExclude: React.FC<{
     const scrollableBoxRef = useRef<HTMLDivElement>(null);
     const listRef = useRef<FixedSizeList>(null);
     const [selectedStubId, setSelectedStubId] = useState<string>();
+    const [searchTerm, setSearchTerm] = useState('');
     const columns = useProjectCurationColumns();
     const projectUser = useProjectUser();
     const canEdit = useUserCanEdit(projectUser || undefined);
@@ -41,9 +44,11 @@ const CurationBoardAIInterfaceExclude: React.FC<{
             .sort((a, b) => (a.title || '').toLocaleLowerCase().localeCompare((b.title || '').toLocaleLowerCase()));
     }, [columns, exclusionTag?.id]);
 
+    const filteredStubs = useMemo(() => filterStubsBySearch(stubs, searchTerm), [stubs, searchTerm]);
+
     const selectedStub: ICurationStubStudy | undefined = useMemo(
-        () => (stubs || []).find((stub) => stub.id === selectedStubId),
-        [selectedStubId, stubs]
+        () => (filteredStubs || []).find((stub) => stub.id === selectedStubId),
+        [selectedStubId, filteredStubs]
     );
 
     const selectedColumnIndex = useMemo(() => {
@@ -53,13 +58,13 @@ const CurationBoardAIInterfaceExclude: React.FC<{
 
     const handleMoveToNextStub = useCallback(() => {
         if (!selectedStub?.id) return;
-        const stubIndex = stubs.findIndex((x) => x.id === selectedStub.id);
+        const stubIndex = filteredStubs.findIndex((x) => x.id === selectedStub.id);
         if (stubIndex < 0) return;
 
-        const nextStub = stubs[stubIndex + 1];
+        const nextStub = filteredStubs[stubIndex + 1];
         if (!nextStub) return;
         setSelectedStubId(nextStub.id);
-    }, [selectedStub?.id, stubs]);
+    }, [selectedStub?.id, filteredStubs]);
 
     const handleUpdateExclusionTag = useCallback(
         (newName: string) => {
@@ -72,20 +77,29 @@ const CurationBoardAIInterfaceExclude: React.FC<{
     const { ref: labelContainerRef, height: labelContainerHeight } = useMeasure<HTMLDivElement>();
     const pxInVh = Math.round(windowHeight - 220 - labelContainerHeight);
 
-    // when the group changes, automatically select the first stub
+    // when the group changes, clear the search and select the first stub
     useEffect(() => {
+        setSearchTerm('');
         if (stubs.length > 0) {
             setSelectedStubId(stubs[0]?.id);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [group.id]);
 
-    // scroll to the selected stub when a stub is selected and the view changes to focus mode
+    // keep the selection within the currently visible (filtered) stubs
+    useEffect(() => {
+        if (filteredStubs.length === 0) return;
+        if (!filteredStubs.some((stub) => stub.id === selectedStubId)) {
+            setSelectedStubId(filteredStubs[0]?.id);
+        }
+    }, [filteredStubs, selectedStubId]);
+
+    // scroll to the selected stub when the selection changes
     useEffect(() => {
         if (!listRef.current) return;
-        const selectedItemIndex = (stubs || []).findIndex((x) => x.id === selectedStubId);
+        const selectedItemIndex = (filteredStubs || []).findIndex((x) => x.id === selectedStubId);
         listRef.current.scrollToItem(selectedItemIndex, 'smart');
-    }, [selectedStubId, stubs]);
+    }, [selectedStubId, filteredStubs]);
 
     // reset scroll position of details page when the selected stub changes
     useEffect(() => {
@@ -117,33 +131,58 @@ const CurationBoardAIInterfaceExclude: React.FC<{
                     <Typography color="warning.dark">No studies have been marked as {group?.label || ''}.</Typography>
                 </Box>
             ) : (
-                <Box sx={{ display: 'flex' }}>
-                    <Box>
-                        <FixedSizeList
-                            height={pxInVh}
-                            itemCount={stubs.length || 0}
-                            width={260}
-                            itemSize={90}
-                            itemKey={(index, data) => data.stubs[index]?.id}
-                            itemData={{
-                                stubs: stubs,
-                                selectedStubId: selectedStub?.id,
-                                onSetSelectedStub: setSelectedStubId,
-                            }}
-                            layout="vertical"
-                            overscanCount={5}
-                            ref={listRef}
-                        >
-                            {CurationStubListItemVirtualizedContainer}
-                        </FixedSizeList>
-                    </Box>
-                    <Box ref={scrollableBoxRef} sx={{ overflowY: 'auto', width: '100%', height: `${pxInVh}px` }}>
-                        <CurationEditableStubSummary
-                            onMoveToNextStub={handleMoveToNextStub}
-                            columnIndex={selectedColumnIndex || 0}
-                            stub={selectedStub}
-                        />
-                    </Box>
+                <Box>
+                    <TextField
+                        size="small"
+                        value={searchTerm}
+                        onChange={(event) => setSearchTerm(event.target.value)}
+                        placeholder="Search excluded studies..."
+                        sx={{ width: '260px', marginBottom: '0.5rem' }}
+                        InputProps={{
+                            startAdornment: (
+                                <InputAdornment position="start">
+                                    <SearchIcon fontSize="small" />
+                                </InputAdornment>
+                            ),
+                        }}
+                    />
+                    {filteredStubs.length === 0 ? (
+                        <Box sx={{ display: 'flex' }}>
+                            <Typography color="warning.dark">No excluded studies match your search.</Typography>
+                        </Box>
+                    ) : (
+                        <Box sx={{ display: 'flex' }}>
+                            <Box>
+                                <FixedSizeList
+                                    height={pxInVh}
+                                    itemCount={filteredStubs.length || 0}
+                                    width={260}
+                                    itemSize={90}
+                                    itemKey={(index, data) => data.stubs[index]?.id}
+                                    itemData={{
+                                        stubs: filteredStubs,
+                                        selectedStubId: selectedStub?.id,
+                                        onSetSelectedStub: setSelectedStubId,
+                                    }}
+                                    layout="vertical"
+                                    overscanCount={5}
+                                    ref={listRef}
+                                >
+                                    {CurationStubListItemVirtualizedContainer}
+                                </FixedSizeList>
+                            </Box>
+                            <Box
+                                ref={scrollableBoxRef}
+                                sx={{ overflowY: 'auto', width: '100%', height: `${pxInVh}px` }}
+                            >
+                                <CurationEditableStubSummary
+                                    onMoveToNextStub={handleMoveToNextStub}
+                                    columnIndex={selectedColumnIndex || 0}
+                                    stub={selectedStub}
+                                />
+                            </Box>
+                        </Box>
+                    )}
                 </Box>
             )}
         </Box>


### PR DESCRIPTION
The excluded-studies view (new curation interface) had no way to search, making it hard to revisit exclusion decisions in a long list. This adds a search box that filters the excluded list — and its keyboard-nav and selection — by title, authors, journal, year, keywords, pmid, and doi. The matching is a small pure helper (`filterStubsBySearch`) with unit tests; an unmatched search shows a "No excluded studies match your search." state.

Closes #1473

**Before** — no search box:

![before](https://raw.githubusercontent.com/lobennett/neurostore/evidence/1473-filter-excluded/before.png)

**After** — typing `reward` filters the list to the match:

![after](https://raw.githubusercontent.com/lobennett/neurostore/evidence/1473-filter-excluded/after.png)