### PR TITLE
[FIX] increment analysis order on POST instead of always 1

### DIFF
--- a/store/backend/neurostore/schemas/data.py
+++ b/store/backend/neurostore/schemas/data.py
@@ -480,10 +480,13 @@ class AnalysisSchema(BaseDataSchema):
         data.pop("weights", None)
 
         if not partial and data.get("order") is None:
-            if data.get("study_id") is not None:
+            study_id = data.get("study_id") or (
+                data.get("study") if isinstance(data.get("study"), str) else None
+            )
+            if study_id:
                 max_order = (
                     db.session.query(func.max(Analysis.order))
-                    .filter_by(study_id=data["study_id"])
+                    .filter_by(study_id=study_id)
                     .scalar()
                 )
                 data["order"] = 1 if max_order is None else max_order + 1

--- a/store/backend/neurostore/tests/api/test_analyses.py
+++ b/store/backend/neurostore/tests/api/test_analyses.py
@@ -285,3 +285,25 @@ def test_create_duplicate_analysis(auth_client, ingest_neurosynth, session):
     original_analysis = resp.json()
     duplicate_analysis = resp_duplicate.json()
     assert original_analysis["id"] == duplicate_analysis["id"]
+
+
+def test_post_analyses_without_order_increments_within_study(auth_client, session):
+    # A fresh study owned by the authenticated user, with no analyses yet.
+    id_ = auth_client.username
+    user = User.query.filter_by(external_id=id_).first()
+    study = Study(name="order increment study", user=user)
+    session.add(study)
+    session.commit()
+
+    payload = {"study": study.id, "name": "order increment analysis"}
+
+    # POST two analyses to the same study, neither carrying an explicit order.
+    resp1 = auth_client.post("/api/analyses/", data=dict(payload))
+    resp2 = auth_client.post("/api/analyses/", data=dict(payload))
+
+    assert resp1.status_code == 200
+    assert resp2.status_code == 200
+
+    # First analysis in the study -> order 1; second -> order 2 (not 1).
+    assert resp1.json()["order"] == 1
+    assert resp2.json()["order"] == 2


### PR DESCRIPTION
## Summary

Fixes #1580. Creating an analysis via `POST /api/analyses/` without an explicit `order` always assigned `order = 1`, so analyses never received a sequential order within their study.

## Root cause

`AnalysisSchema.load_values` (a `@pre_load` hook) auto-assigns the order by querying the current max for the study:

```python
if data.get("study_id") is not None:
    max_order = db.session.query(func.max(Analysis.order)).filter_by(study_id=data["study_id"]).scalar()
    data["order"] = 1 if max_order is None else max_order + 1
else:
    data["order"] = 1
```

The field is declared `study_id = fields.String(data_key="study")`. `@pre_load` runs on the **raw payload**, before marshmallow maps the `data_key`, so the study id is present under the key `study`, not `study_id`. `data.get("study_id")` was therefore always `None`, the `else` branch always ran, and every new analysis got `order = 1`.

## Fix

Resolve the id from the `study` data_key (keeping the `study_id` fallback and a nested-object guard), mirroring the pattern `PointSchema.process_values` already uses for the identical case:

```python
study_id = data.get("study_id") or (
    data.get("study") if isinstance(data.get("study"), str) else None
)
if study_id:
    max_order = db.session.query(func.max(Analysis.order)).filter_by(study_id=study_id).scalar()
    data["order"] = 1 if max_order is None else max_order + 1
else:
    data["order"] = 1
```

`AnalysisSchema` is the only change; `PointSchema` already handled this correctly.

## Tests

The existing `test_post_analysis_without_order` only asserted `order is not None`, which passed even with the bug (order was `1`, not `None`) — that gap let the bug through. Adds `test_post_analyses_without_order_increments_within_study`: creates a fresh study and POSTs two order-less analyses, asserting orders `1` then `2`. Fails on the old code (both `1`), passes with the fix.

```
python -m pytest neurostore/tests/api/test_analyses.py -k order
# 3 passed
```
